### PR TITLE
change text alpha to beta

### DIFF
--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -14,7 +14,7 @@ const Banner = () => {
             feedbackUrl && (
             <p className="govuk-phase-banner__content">
                 <strong className="govuk-tag govuk-phase-banner__content__tag" role="tag">
-                Alpha
+                Beta
                 </strong>
                 <span className="govuk-phase-banner__text">
                 This is a new service – your <a className="govuk-link" href={feedbackUrl} role="link" target="_blank">feedback</a> will help us to improve it.


### PR DESCRIPTION
Ticket: https://trello.com/c/xgOuKBZ2/281-bug-it-says-alpha-on-the-banner-but-it-should-say-beta