### PR TITLE
Amend language to include the word 'can'

### DIFF
--- a/src/components/process/index.tsx
+++ b/src/components/process/index.tsx
@@ -20,9 +20,9 @@ const aplicationStageStyle = (value: string) => {
 const applicationStageMessage = (stage: string, status: string) => {
   const consultation: { [key: string]: string } = {
     "in progress":
-      "People in the local community share feedback and comment on the proposed plans.",
+      "People in the local community can share feedback and comment on the proposed plans.",
     extended:
-      "People in the local community share feedback and comment on the proposed plans",
+      "People in the local community can share feedback and comment on the proposed plans",
   };
 
   const assessment: { [key: string]: string } = {


### PR DESCRIPTION
Quick fix to amend language to include the word 'can': ‘People in the local community **can** share feedback……’'

![image](https://github.com/tpximpact/council-digital-site-notice/assets/107464669/a76721e8-d70e-4535-92cf-fedb6ef2b484)
