### PR TITLE
add image name validation

### DIFF
--- a/sanity/schemas/planningApplication.ts
+++ b/sanity/schemas/planningApplication.ts
@@ -89,6 +89,19 @@ export default defineType({
           type: "image",
         },
       ],
+      validation: (Rule) =>
+        Rule.custom((field: any) => {
+          const duplicates = field.filter((item: any, index: number) =>
+            field.some(
+              (elem: any, idx: number) =>
+                elem.asset._ref === item.asset._ref && idx !== index,
+            ),
+          );
+          if (duplicates?.length > 0) {
+            return "You can't upload an image twice";
+          }
+          return true;
+        }),
       description: "Optional",
     }),
     defineField({


### PR DESCRIPTION
Ticket: https://tpximpact.atlassian.net/browse/DSNPI-147?atlOrigin=eyJpIjoiYzkyNTQwYTdlY2Q4NGJkNGIxMDIyYTllZTkzMjI3YTMiLCJwIjoiaiJ9

We still can upload image with the same name (we don't use the name for anything, just for sanity display), but I create a validation that not allow to upload the same image twice