### PR TITLE
Fix location search

### DIFF
--- a/__tests__/src/lib/dataService.test.ts
+++ b/__tests__/src/lib/dataService.test.ts
@@ -83,13 +83,13 @@ describe("DataClient", () => {
 
         const response = await dataClient.getAllSiteNotices(
           undefined,
-          undefined,
           location,
+          undefined,
         );
 
         expect(
           sanityClient.getActiveApplicationsByLocation,
-        ).toHaveBeenCalledWith(undefined, undefined, location);
+        ).toHaveBeenCalledWith(undefined, location, undefined);
         expect(response.results.length).toBe(2);
         expect(response.results[0]._id).toBe("1");
         expect(response.results[1]._id).toBe("2");

--- a/__tests__/src/lib/dataService.test.ts
+++ b/__tests__/src/lib/dataService.test.ts
@@ -83,8 +83,8 @@ describe("DataClient", () => {
 
         const response = await dataClient.getAllSiteNotices(
           undefined,
-          location,
           undefined,
+          location,
         );
 
         expect(

--- a/__tests__/src/lib/dataService.test.ts
+++ b/__tests__/src/lib/dataService.test.ts
@@ -61,5 +61,40 @@ describe("DataClient", () => {
       expect(openDataClient2.getOpenDataApplications).not.toHaveBeenCalled();
       expect(response).toEqual(resultData);
     });
+    describe("getAllSiteNotices by location", () => {
+      it("should filter and sort site notices by location when provided", async () => {
+        const sanityClient = new SanityClient();
+        const openDataClient = new OpenDataClient();
+        const dataClient = new DataClient(sanityClient, openDataClient);
+
+        const location = { latitude: 40.7128, longitude: -74.006 };
+
+        const sanityResultData = {
+          results: [
+            { _id: "1", applicationNumber: "123", distance: 1000 },
+            { _id: "2", applicationNumber: "456", distance: 5000 },
+          ],
+          total: 2,
+        };
+
+        jest
+          .spyOn(sanityClient, "getActiveApplicationsByLocation")
+          .mockResolvedValue(sanityResultData);
+
+        const response = await dataClient.getAllSiteNotices(
+          undefined,
+          undefined,
+          location,
+        );
+
+        expect(
+          sanityClient.getActiveApplicationsByLocation,
+        ).toHaveBeenCalledWith(undefined, undefined, location);
+        expect(response.results.length).toBe(2);
+        expect(response.results[0]._id).toBe("1");
+        expect(response.results[1]._id).toBe("2");
+        expect(response.total).toBe(2);
+      });
+    });
   });
 });

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -26,11 +26,13 @@ export class DataClient {
     // lastId?: string,
     itemsPerPage?: number,
     offSet?: number,
+    location?: any,
   ): Promise<siteNoticeResponse> {
     const resultData = await this.sanityClient.getActiveApplications(
       // lastId,
       itemsPerPage,
       offSet,
+      location,
     );
     let openDataPosts = [];
     if (this.integrationMethod == "OpenData") {

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -25,8 +25,8 @@ export class DataClient {
   async getAllSiteNotices(
     // lastId?: string,
     offSet?: number,
-    location?: { latitude: number; longitude: number },
     itemsPerPage?: number,
+    location?: { latitude: number; longitude: number },
   ): Promise<siteNoticeResponse> {
     let resultData;
     if (location) {

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -24,23 +24,23 @@ export class DataClient {
 
   async getAllSiteNotices(
     // lastId?: string,
-    itemsPerPage?: number,
     offSet?: number,
     location?: { latitude: number; longitude: number },
+    itemsPerPage?: number,
   ): Promise<siteNoticeResponse> {
     let resultData;
     if (location) {
       resultData = await this.sanityClient.getActiveApplicationsByLocation(
         // lastId,
-        itemsPerPage,
         offSet,
         location,
+        itemsPerPage,
       );
     } else {
       resultData = await this.sanityClient.getActiveApplications(
         // lastId,
-        itemsPerPage,
         offSet,
+        itemsPerPage,
       );
     }
     let openDataPosts = [];

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -26,14 +26,23 @@ export class DataClient {
     // lastId?: string,
     itemsPerPage?: number,
     offSet?: number,
-    location?: any,
+    location?: { latitude: number; longitude: number },
   ): Promise<siteNoticeResponse> {
-    const resultData = await this.sanityClient.getActiveApplications(
-      // lastId,
-      itemsPerPage,
-      offSet,
-      location,
-    );
+    let resultData;
+    if (location) {
+      resultData = await this.sanityClient.getActiveApplicationsByLocation(
+        // lastId,
+        itemsPerPage,
+        offSet,
+        location,
+      );
+    } else {
+      resultData = await this.sanityClient.getActiveApplications(
+        // lastId,
+        itemsPerPage,
+        offSet,
+      );
+    }
     let openDataPosts = [];
     if (this.integrationMethod == "OpenData") {
       openDataPosts = await this.openDataClient.getOpenDataApplications(

--- a/src/lib/sanityClient.ts
+++ b/src/lib/sanityClient.ts
@@ -32,12 +32,11 @@ export class SanityClient {
   }
 
   async getActiveApplications(
-    itemsPerPage?: number,
     offSet: number = 0,
+    itemsPerPage?: number,
   ): Promise<sanityApplicationResponse> {
-    let query;
-
-    query = `{
+    try {
+      const query = `{
       "results": *[_type == "planning-application" && isActive == true && !(_id in path("drafts.**"))] | order(_id) 
         ${itemsPerPage ? `[${offSet}...${offSet + itemsPerPage}]` : ""} {
           _id, 
@@ -50,47 +49,50 @@ export class SanityClient {
       "total": count(*[_type == "planning-application" && isActive == true && !(_id in path("drafts.**"))])
     }`;
 
-    const response = await this.client.fetch(query);
-    return response;
+      const response = await this.client.fetch(query);
+      return response;
+    } catch (error) {
+      throw new Error("Error fetching data from Sanity");
+    }
   }
 
   async getActiveApplicationsByLocation(
-    itemsPerPage?: number,
     offSet: number = 0,
-    location?: { latitude: number; longitude: number },
+    location: { latitude: number; longitude: number },
+    itemsPerPage?: number,
   ): Promise<sanityApplicationResponse> {
-    let query;
-    if (
-      location &&
-      typeof location.latitude === "number" &&
-      typeof location.longitude === "number"
-    ) {
-      query = `{
-        "results": 
-        *[_type == "planning-application" && defined(location) && isActive == true && !(_id in path("drafts.**"))] | order(geo::distance(location, geo::latLng(${location.latitude}, ${location.longitude}))) ${itemsPerPage ? `[${offSet}...${offSet + itemsPerPage}]` : ""} 
-           {
-            _id, 
-            image_head, 
-            name, 
-            applicationNumber, 
-            applicationName, 
-            address,
-            "distance": geo::distance(location, geo::latLng(${location.latitude}, ${location.longitude}))
-          },
-        "total": count(*[_type == "planning-application" && defined(location) && isActive == true && !(_id in path("drafts.**"))]),
-      }`;
+    if (!location) {
+      throw new Error("Valid location is required.");
     }
 
-    const response = await this.client.fetch(query);
-    if (response.results) {
-      response.results.forEach((result: { distance: number }) => {
-        if (result.distance) {
-          // convert the distance of each distance from meters to miles
-          result.distance = result.distance * 0.000621371192;
-          result.distance = Math.round(result.distance);
-        }
-      });
+    try {
+      const query = `{
+      "results": 
+      *[_type == "planning-application" && defined(location) && isActive == true && !(_id in path("drafts.**"))] | order(geo::distance(location, geo::latLng(${location.latitude}, ${location.longitude}))) ${itemsPerPage ? `[${offSet}...${offSet + itemsPerPage}]` : ""} 
+         {
+          _id, 
+          image_head, 
+          name, 
+          applicationNumber, 
+          applicationName, 
+          address,
+          "distance": geo::distance(location, geo::latLng(${location.latitude}, ${location.longitude}))
+        },
+      "total": count(*[_type == "planning-application" && defined(location) && isActive == true && !(_id in path("drafts.**"))]),
+    }`;
+      const response = await this.client.fetch(query);
+      if (response.results) {
+        response.results.forEach((result: { distance: number }) => {
+          if (result.distance) {
+            // convert the distance of each distance from meters to miles
+            result.distance = result.distance * 0.000621371192;
+            result.distance = Math.round(result.distance);
+          }
+        });
+      }
+      return response;
+    } catch (error) {
+      throw new Error("Error fetching data from Sanity");
     }
-    return response;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,7 @@ export const itemsPerPage = 6;
 const dataClient = new DataClient(new SanityClient(), new OpenDataClient());
 
 export async function getStaticProps() {
-  const data = await dataClient.getAllSiteNotices(0, undefined, itemsPerPage);
+  const data = await dataClient.getAllSiteNotices(0, itemsPerPage);
   return {
     props: {
       data: data.results,
@@ -51,8 +51,8 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
 
     const newData = await dataClient.getAllSiteNotices(
       newOffset,
-      location,
       totalPage,
+      location,
     );
     setDisplayData(newData?.results as Data[]);
     setDynamicTotalResults(newData?.total as number);
@@ -75,8 +75,8 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
     // Fetching sorted applications based on lat/long
     const newData = await dataClient.getAllSiteNotices(
       0,
-      location,
       itemsPerPage,
+      location,
     );
     setDisplayData(newData?.results as Data[]);
     setDynamicTotalResults(newData?.total as number);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,50 +52,27 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
     setDisplayData(newData?.results as Data[]);
   };
 
-  // this needs to be refactored once data is held in Sanity
   const onSearchPostCode = async () => {
     let location: any;
-
-    if (postcode != null) {
-      setLocationNotFound(false);
-      location = await getLocationFromPostcode(postcode);
-
-      if (location == null) {
-        setLocationNotFound(true);
-      }
+    if (!postcode) {
+      setLocationNotFound(true);
+      return;
     }
+    location = await getLocationFromPostcode(postcode);
+    if (!location) {
+      setLocationNotFound(true);
+      return;
+    }
+    setLocationNotFound(false);
     setLocation(location);
 
-    if (location) {
-      //remove any data elements that dont have a location or location.lat location.lng, keep the elements so i can attache them to the end of the array
-      const dataWithoutLocation = data.filter((el) => !el.location);
-      dataWithoutLocation.forEach((el) => {
-        const index = data.indexOf(el);
-        if (index !== -1) {
-          data.splice(index, 1);
-        }
-      });
-
-      const sortedData = data.sort((a, b) => {
-        if (!a.location || !b.location) {
-          return -1;
-        }
-        const distanceA = getDistance(
-          { latitude: location.latitude, longitude: location.longitude },
-          { latitude: a.location.lat, longitude: a.location.lng },
-        );
-        const distanceB = getDistance(
-          { latitude: location.latitude, longitude: location.longitude },
-          { latitude: b.location.lat, longitude: b.location.lng },
-        );
-        //adds the distance to the object
-        a.distance = convertDistance(distanceA, "mi").toFixed(2);
-        return distanceA - distanceB;
-      });
-      //adds the data without location to the end of the array
-      sortedData.push(...dataWithoutLocation);
-      setDisplayData(sortedData as Data[]);
-    }
+    // Fetching sorted applications based on lat/long
+    const newData = await dataClient.getAllSiteNotices(
+      itemsPerPage,
+      0,
+      location,
+    );
+    setDisplayData(newData?.results as Data[]);
   };
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,7 @@ export const itemsPerPage = 6;
 const dataClient = new DataClient(new SanityClient(), new OpenDataClient());
 
 export async function getStaticProps() {
-  const data = await dataClient.getAllSiteNotices(itemsPerPage, 0);
+  const data = await dataClient.getAllSiteNotices(0, undefined, itemsPerPage);
   return {
     props: {
       data: data.results,
@@ -50,9 +50,9 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
       newTotalPagecount >= itemsPerPage ? itemsPerPage : newTotalPagecount;
 
     const newData = await dataClient.getAllSiteNotices(
-      totalPage,
       newOffset,
       location,
+      totalPage,
     );
     setDisplayData(newData?.results as Data[]);
     setDynamicTotalResults(newData?.total as number);
@@ -74,9 +74,9 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
 
     // Fetching sorted applications based on lat/long
     const newData = await dataClient.getAllSiteNotices(
-      itemsPerPage,
       0,
       location,
+      itemsPerPage,
     );
     setDisplayData(newData?.results as Data[]);
     setDynamicTotalResults(newData?.total as number);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,12 +34,14 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
   const [location, setLocation] = useState<any>();
   const [locationNotFound, setLocationNotFound] = useState<boolean>(false);
   const [displayData, setDisplayData] = useState<Data[]>();
+  const [dynamicTotalResults, setDynamicTotalResults] =
+    useState<number>(resultsTotal);
 
   useEffect(() => {
     setDisplayData(data as Data[]);
   }, [data]);
 
-  const pageCount = Math.ceil(resultsTotal / itemsPerPage);
+  const pageCount = Math.ceil(dynamicTotalResults / itemsPerPage);
 
   const handlePageClick = async (event: any) => {
     const newOffset = (event.selected * itemsPerPage) % resultsTotal;
@@ -53,6 +55,7 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
       location,
     );
     setDisplayData(newData?.results as Data[]);
+    setDynamicTotalResults(newData?.total as number);
   };
 
   const onSearchPostCode = async () => {
@@ -76,6 +79,7 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
       location,
     );
     setDisplayData(newData?.results as Data[]);
+    setDynamicTotalResults(newData?.total as number);
   };
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,8 +47,11 @@ const Home = ({ data, resultsTotal }: PaginationType) => {
     const totalPage =
       newTotalPagecount >= itemsPerPage ? itemsPerPage : newTotalPagecount;
 
-    const newData = await dataClient.getAllSiteNotices(totalPage, newOffset);
-    console.log(newData.results);
+    const newData = await dataClient.getAllSiteNotices(
+      totalPage,
+      newOffset,
+      location,
+    );
     setDisplayData(newData?.results as Data[]);
   };
 


### PR DESCRIPTION
Refactors the search by postcode implementation with GROQ and distance queries. 
The user enters a postcode which is converted to latitude and longitude. Results are queried and ordered using GROQ `geo::distance` function that returns the distance between the user entered location and the location in the planning application schema. As this returns the distance in meters, it is then converted to miles and rounded.
The searched location state is maintained during pagination.

n.b: if a planning application does not have a location (latitude and longitude), it is not shown in the search results. Previously we added this to the end of the results but now it is no longer shown.
![image](https://github.com/tpximpact/council-digital-site-notice/assets/107464669/698ced5a-c2c3-4e0d-ac60-00a18eb54795)
