### PR TITLE
Add decimal point to distance

### DIFF
--- a/src/lib/sanityClient.ts
+++ b/src/lib/sanityClient.ts
@@ -86,7 +86,7 @@ export class SanityClient {
           if (result.distance) {
             // convert the distance of each distance from meters to miles
             result.distance = result.distance * 0.000621371192;
-            result.distance = Math.round(result.distance);
+            result.distance = parseFloat(result.distance.toFixed(1));
           }
         });
       }


### PR DESCRIPTION
Use ParseFloat instead of rounding the distance value so that planning applications' distance is more accurate. Before it was showing 0 miles if the value was 0.1, now it shows 0.1 miles
![image](https://github.com/tpximpact/council-digital-site-notice/assets/107464669/91330899-580b-49b2-ad67-1b2b9fa1a1de)
