### PR TITLE
DSNPI 254 - Align page numbers

### DIFF
--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -100,7 +100,7 @@
   background-color: #1d70b8;
   color: white;
   font-weight: 700;
-  align-self: center;
+  align-self: baseline;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
Page numbers were not aligned when a page was selected, this is now fixed.
![image](https://github.com/tpximpact/council-digital-site-notice/assets/107464669/2e1528e5-0724-406b-a480-77ba7a3c9cf1)
