### PR TITLE
Gallery validation fix

### DIFF
--- a/sanity/schemas/planningApplication.ts
+++ b/sanity/schemas/planningApplication.ts
@@ -109,6 +109,9 @@ export default defineType({
       ],
       validation: (Rule) =>
         Rule.custom((field: any) => {
+          if (!Array.isArray(field) || field.length === 0) {
+            return true;
+          }
           const duplicates = field.filter((item: any, index: number) =>
             field.some(
               (elem: any, idx: number) =>


### PR DESCRIPTION
[Ticket 264](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-264)

Quick fix to check for image array presence before running the validation that checks for duplicates. 

Validation error was blocking publishing without images - `image_gallery: Exception occurred while validating value: Cannot read properties of undefined (reading 'filter')`