### PR TITLE
Content spacing

### DIFF
--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -32,6 +32,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0 13px;
+  justify-content: space-between;
 }
 
 @media screen and (max-width: 959px) {


### PR DESCRIPTION
[Ticket 252](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-252)
Minor change adding space between the planning application cards to align with the page grid width properly.

The first bulletpoint in the ticket is not required because the sizing of the header is bigger on the build than the figma design, which makes the spacing look the way it does. 