### PR TITLE
cache getGlobalContent

### DIFF
--- a/__tests__/application.test.ts
+++ b/__tests__/application.test.ts
@@ -6,6 +6,15 @@ import handler from "@/app/api/application/route";
 jest.mock("../src/app/actions/actions");
 jest.mock("../src/app/actions/validator");
 jest.mock("../src/app/lib/apiKey");
+jest.mock("react", () => {
+  const testCache = <T extends (...args: Array<unknown>) => unknown>(func: T) =>
+    func;
+  const originalModule = jest.requireActual("react");
+  return {
+    ...originalModule,
+    cache: testCache,
+  };
+});
 
 describe.skip("Applications API", () => {
   beforeEach(() => {

--- a/__tests__/applications.test.ts
+++ b/__tests__/applications.test.ts
@@ -6,6 +6,15 @@ import { verifyApiKey } from "../src/app/lib/apiKey";
 jest.mock("../src/app/actions/actions");
 jest.mock("../src/app/actions/validator");
 jest.mock("../src/app/lib/apiKey");
+jest.mock("react", () => {
+  const testCache = <T extends (...args: Array<unknown>) => unknown>(func: T) =>
+    func;
+  const originalModule = jest.requireActual("react");
+  return {
+    ...originalModule,
+    cache: testCache,
+  };
+});
 
 describe.skip("Applications API", () => {
   beforeEach(() => {

--- a/__tests__/comments.test.ts
+++ b/__tests__/comments.test.ts
@@ -8,6 +8,16 @@ jest.mock("../src/app/actions/email", () => ({
   savefeedbackToGoogleSheet: jest.fn(),
 }));
 
+jest.mock("react", () => {
+  const testCache = <T extends (...args: Array<unknown>) => unknown>(func: T) =>
+    func;
+  const originalModule = jest.requireActual("react");
+  return {
+    ...originalModule,
+    cache: testCache,
+  };
+});
+
 describe("comments API", () => {
   let data: any;
 

--- a/__tests__/components/questions.test.js
+++ b/__tests__/components/questions.test.js
@@ -11,7 +11,6 @@ beforeEach(() => {
 
 jest.mock("../../src/app/actions/actions", () => ({
   getGlobalContent: jest.fn(),
-  globalContentRevalidate: jest.fn(),
 }));
 
 jest.mock("next/navigation", () => ({

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2,6 +2,15 @@ import { render, screen } from "@testing-library/react";
 import Home from "../src/app/(main)/page";
 import "@testing-library/jest-dom";
 
+jest.mock("react", () => {
+  const testCache = (func) => func;
+  const originalModule = jest.requireActual("react");
+  return {
+    ...originalModule,
+    cache: testCache,
+  };
+});
+
 describe("Home", () => {
   it("renders a heading", () => {
     render(<Home />);

--- a/__tests__/snapshot.js
+++ b/__tests__/snapshot.js
@@ -1,6 +1,15 @@
 import { render } from "@testing-library/react";
 import Home from "../src/app/(main)/page";
 
+jest.mock("react", () => {
+  const testCache = (func) => func;
+  const originalModule = jest.requireActual("react");
+  return {
+    ...originalModule,
+    cache: testCache,
+  };
+});
+
 it("renders homepage unchanged", () => {
   const { container } = render(<Home />);
   expect(container).toMatchSnapshot();

--- a/src/app/(main)/concern-info.tsx
+++ b/src/app/(main)/concern-info.tsx
@@ -1,7 +1,7 @@
-import { globalContentRevalidate } from "../actions/actions";
+import { getGlobalContent } from "../actions/actions";
 
 async function ConcernInfo() {
-  const globalConfig: any = globalContentRevalidate();
+  const globalConfig: any = getGlobalContent();
   return <p className="govuk-body">{globalConfig?.concernContent}</p>;
 }
 

--- a/src/app/(main)/cookie-policy/page.tsx
+++ b/src/app/(main)/cookie-policy/page.tsx
@@ -1,7 +1,7 @@
-import { globalContentRevalidate } from "@/app/actions/actions";
+import { getGlobalContent } from "@/app/actions/actions";
 
 const CookiePolicyPage = async () => {
-  const globalConfig: any = await globalContentRevalidate();
+  const globalConfig: any = await getGlobalContent();
   return <p className="govuk-body">{globalConfig?.cookiePolicyContent}</p>;
 };
 

--- a/src/app/(main)/planning-applications/[id]/feedback/instructions.tsx
+++ b/src/app/(main)/planning-applications/[id]/feedback/instructions.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { urlFor } from "@/app/actions/client";
 import { getLocalStorage } from "../../../../lib/application";
 import { Data } from "../../../../lib/type";
-import { globalContentRevalidate } from "@/app/actions/actions";
+import { getGlobalContent } from "@/app/actions/actions";
 
 function Instructions() {
   const [application, setApplication] = useState<Data>();
@@ -13,7 +13,7 @@ function Instructions() {
 
   useEffect(() => {
     (async () => {
-      const globalConfig: any = await globalContentRevalidate();
+      const globalConfig: any = await getGlobalContent();
       const getStorage = getLocalStorage({
         key: "application",
         defaultValue: {},

--- a/src/app/(main)/planning-applications/[id]/thank-you/page.tsx
+++ b/src/app/(main)/planning-applications/[id]/thank-you/page.tsx
@@ -7,7 +7,7 @@ import { Data } from "../../../../lib/type";
 import { urlFor } from "@/app/actions/client";
 import { getLocalStorage } from "../../../../lib/application";
 import Breadcrumbs from "@/components/breadcrumbs";
-import { globalContentRevalidate } from "@/app/actions/actions";
+import { getGlobalContent } from "@/app/actions/actions";
 
 const FeedbackMessage = () => {
   const [globalConfig, setGlobalConfig] = useState<any>();
@@ -16,7 +16,7 @@ const FeedbackMessage = () => {
 
   useEffect(() => {
     (async () => {
-      const fetchGlobalConfig: any = await globalContentRevalidate();
+      const fetchGlobalConfig: any = await getGlobalContent();
       setGlobalConfig(fetchGlobalConfig);
       const initialValue = getLocalStorage({
         key: "application",

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -1,22 +1,16 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
 import { client } from "./client";
 import { sendEmail, createEmailData } from "./email";
 import { savefeedbackToGoogleSheet } from "./email";
 import { postCodeRegex } from "../lib/application";
 import { cookies } from "next/headers";
+import { cache } from "react";
 
-export async function getGlobalContent() {
-  const info = await client.fetch('*[_type == "global-content"][0]', {
-    tags: ["globalContent"],
-  });
+export const getGlobalContent = cache(async () => {
+  const info = await client.fetch('*[_type == "global-content"][0]');
   return info;
-}
-
-export async function globalContentRevalidate() {
-  revalidateTag("globalContent");
-}
+});
 
 export async function getApplicationById(id: string) {
   const query =

--- a/src/components/feedback-information/index.tsx
+++ b/src/components/feedback-information/index.tsx
@@ -19,7 +19,6 @@ function FeedbackInformation({
   useEffect(() => {
     (async () => {
       const fetchGlobalConfig: any = await getGlobalContent();
-      console.log({fetchGlobalConfig}, 'feedback-info')
       setGlobalConfig(fetchGlobalConfig);
       setUrlConcern(
         fetchGlobalConfig?.concernUrl

--- a/src/components/feedback-information/index.tsx
+++ b/src/components/feedback-information/index.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/button";
 import { ArrowIcon } from "../../../public/assets/icons";
 import { useEffect, useState } from "react";
 import { getLocalStorage } from "@/app/lib/application";
-import { globalContentRevalidate } from "@/app/actions/actions";
+import { getGlobalContent } from "@/app/actions/actions";
 
 function FeedbackInformation({
   onChangeQuestion,
@@ -18,7 +18,8 @@ function FeedbackInformation({
 
   useEffect(() => {
     (async () => {
-      const fetchGlobalConfig: any = await globalContentRevalidate();
+      const fetchGlobalConfig: any = await getGlobalContent();
+      console.log({fetchGlobalConfig}, 'feedback-info')
       setGlobalConfig(fetchGlobalConfig);
       setUrlConcern(
         fetchGlobalConfig?.concernUrl

--- a/src/components/personal-details/index.tsx
+++ b/src/components/personal-details/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../app/lib/feedback-validation";
 import { PersonalDetailsForm } from "../../app/lib/type";
 import { getLocalStorage } from "../../app/lib/application";
-import { globalContentRevalidate } from "../../app/actions/actions";
+import { getGlobalContent } from "../../app/actions/actions";
 
 const PersonalDetails = ({
   onChangeQuestion,
@@ -59,7 +59,7 @@ const PersonalDetails = ({
 
   useEffect(() => {
     (async () => {
-      const fetchGlobalConfig: any = await globalContentRevalidate();
+      const fetchGlobalConfig: any = await getGlobalContent();
       setGlobalConfig(fetchGlobalConfig);
 
       const applicationStorage = getLocalStorage({

--- a/src/components/process/index.tsx
+++ b/src/components/process/index.tsx
@@ -7,7 +7,7 @@ import {
   applicationStageMessage,
 } from "@/app/lib/application";
 import { useEffect, useState } from "react";
-import { globalContentRevalidate } from "@/app/actions/actions";
+import { getGlobalContent } from "@/app/actions/actions";
 function Process({
   data,
   consultationDeadline,
@@ -19,7 +19,7 @@ function Process({
 
   useEffect(() => {
     (async () => {
-      const fetchGlobalConfig = await globalContentRevalidate();
+      const fetchGlobalConfig = await getGlobalContent();
       setGlobalConfig(fetchGlobalConfig);
     })();
   }, []);


### PR DESCRIPTION
Ticket: https://tpximpact.atlassian.net/browse/DSNPI-337?atlOrigin=eyJpIjoiN2JmNWY5YmU2YmU1NGM0NmI4ZDAzNzcxMjdkNjU1NjAiLCJwIjoiaiJ9

The revalidateTag does not work with CMS. I wrapped getGlobalConfig inside react cache, in this case the fetching is happening one time and every other time we call the function is returning the cache. 