### PR TITLE
Update permissions to GITHUB_TOKEN for this action

### DIFF
--- a/.github/workflows/send-event-staging.yml
+++ b/.github/workflows/send-event-staging.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - staging
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   send-event:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've started getting this error when events are dispatched to the deployment repo

```
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/repos/repos#create-a-repository-dispatch-event",
  "status": "403"
}
```