### PR TITLE
DSNPI-946 dsn fix cookie banner buttons

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -29,16 +29,25 @@ export default async function MainLayout({
 }) {
   const environment = process.env.NODE_ENV;
   const cookieStore = cookies();
-  const isShowCookie = cookieStore.get("isShowCookie")?.value || true;
-  const isConsentCookie = cookieStore.get("isConsentCookie")?.value || false;
+  const isShowCookieValue = cookieStore.get("isShowCookie")?.value;
+  const isShowCookie =
+    isShowCookieValue === undefined ? true : isShowCookieValue === "true";
+  const isConsentCookieValue = cookieStore.get("isConsentCookie")?.value;
+  const isConsentCookie =
+    isConsentCookieValue === undefined
+      ? false
+      : isConsentCookieValue === "true";
 
+  console.log(typeof isShowCookie, isShowCookie);
   return (
     <>
       {isShowCookie && <CookiesBanner />}
       {isConsentCookie &&
         environment !== "development" &&
         globalContent?.googleAnalytics && (
-          <GoogleAnalytics gaId={globalContent?.googleAnalytics} />
+          <>
+            <GoogleAnalytics gaId={globalContent?.googleAnalytics} />
+          </>
         )}
       <a href="#main" className="govuk-skip-link" data-module="govuk-skip-link">
         Skip to main content

--- a/src/components/cookies/index.tsx
+++ b/src/components/cookies/index.tsx
@@ -1,8 +1,10 @@
 "use client";
 import Link from "next/link";
 import { createCookies } from "@/app/actions/actions";
+import { useRouter } from "next/navigation";
 
 const CookiesBanner = () => {
+  const router = useRouter();
   return (
     <div
       className="govuk-cookie-banner"
@@ -34,6 +36,7 @@ const CookiesBanner = () => {
             data-module="govuk-button"
             onClick={() => {
               createCookies(true);
+              router.refresh();
             }}
           >
             Accept analytics cookies


### PR DESCRIPTION
https://tpximpact.atlassian.net/browse/DSNPI-946

I'm not sure the cookies have ever worked on DSN? showCookieBanner and Cookie acceptance were set to `"true"`/`"false"` not `true`/`false` so the jsx would never have worked or always worked because a string is considered truthy

- fixed show/hide banner logic
- when accepting cookies the page now reloads to load in the analytics otherwise the analytics would only load after a page refresh or the users next visit