### PR TITLE
BUGFIX: branch protection check failing

### DIFF
--- a/.github/workflows/main-branch-protection.yml
+++ b/.github/workflows/main-branch-protection.yml
@@ -1,10 +1,15 @@
 # only allow merging from the staging branch or a hotfix/ branch into main
 name: Main Branch Protection
 
+# By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened
+# Added edited in here so that if the PR is edited eg the base branch is changed, the workflow will run
 on:
   pull_request:
-    branches:
-      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 jobs:
   check-branch:
@@ -12,10 +17,15 @@ jobs:
     steps:
       - name: Check branch
         run: |
-          if [[ ${GITHUB_HEAD_REF} != staging ]] && ! [[ ${GITHUB_HEAD_REF} =~ ^hotfix/ ]]; 
+          echo "This branch is called: $GITHUB_HEAD_REF"
+          echo "This PR is hoping to be merged into: $GITHUB_BASE_REF"
+          if [[ ${GITHUB_BASE_REF} == main ]]; 
           then
-            echo "Error: Pull request must come from 'staging' or 'hotfix/' branch"
-            exit 1
+            if [[ ${GITHUB_HEAD_REF} != staging ]] && ! [[ ${GITHUB_HEAD_REF} =~ ^hotfix/ ]]; 
+            then
+              echo "Error: Pull request must come from 'staging' or 'hotfix/' branch"
+              exit 1
+            fi
           fi
 
       - name: Create comment


### PR DESCRIPTION
So if you're a plum like me I kept forgetting to change my base from `main` to `staging`, so the check was running only if the base was `main` and after I change it to `staging` that meant that the check will never run again and my tests will look as if they've failed when they haven't.

So I've updated the script to look at all target bases but we also need to include types, by default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened but the edited type is what will let it run again when I inevitably forget (again) to set the right base branch!

