### PR TITLE
DSNPI-996 bug in comment flow

### DIFF
--- a/src/app/(main)/planning-applications/[id]/feedback/page.tsx
+++ b/src/app/(main)/planning-applications/[id]/feedback/page.tsx
@@ -11,7 +11,8 @@ import PageCenter from "@/components/pageCenter";
 
 export const dynamic = "force-dynamic";
 
-const Feedback = () => {
+const Feedback = ({ params }: { params: { id: string } }) => {
+  const { id: applicationId } = params;
   const [application, setApplication] = useState<PlanningApplication>();
   const [question, setQuestion] = useState<number>(0);
   const [initialized, setInitialized] = useState(false);
@@ -25,6 +26,18 @@ const Feedback = () => {
         defaultValue: {},
       });
 
+      // if we've been sent a link to /feedback and don't have an application stored, redirect to the application page
+      if (
+        Object.keys(storedApplication).length === 0 &&
+        storedApplication.constructor === Object
+      ) {
+        console.info(
+          "Redirecting back to application as no application data stored",
+        );
+        router.push(`/planning-applications/${applicationId}`);
+        return;
+      }
+
       if (globalConfig.globalEnableComments === false) {
         router.push(`/planning-applications/${storedApplication?._id}`);
         return;
@@ -35,7 +48,7 @@ const Feedback = () => {
     };
 
     initializePage();
-  }, [router]);
+  }, [router, applicationId]);
 
   const onChangeQuestion = () => {
     const getStorageSelectedCheckbox = getLocalStorage({


### PR DESCRIPTION
This bug was blocking some of the accessibility testing, if you've never visited DSN before and someone sends you a link to a /feedback page we don't have the application blurb in the local storage yet from the application page, which was giving me errors on some of the browsers I was trying.

This isn't an ideal fix but the larger fix would be reworking the local storage and the comments and well nope!

This fix just redirects you back to the application page if you don't have that blurb present. I've only just encountered this bug for the first time today so hopefully it wont come up often!

```json
{"address":"135-149 Shaftesbury Avenue London WC2H 8AH","image_head":{"_type":"image","asset":{"_ref":"image-f1054a6aac24931ec307ca179a6c38c87bf8e529-818x719-jpg","_type":"reference"}},"image_gallery":[{"_type":"image","_key":"d2d57bec4a12","asset":{"_ref":"image-fc381812bb6d0a68b41c01ea0ce2f9252c636e93-1232x737-jpg","_type":"reference"}},{"_key":"1f8b39198123","asset":{"_ref":"image-2ad2fa03f3a2b269d5106b5aad5aeabada0648e2-1239x537-jpg","_type":"reference"},"_type":"image"},{"_type":"image","_key":"bd579cb1214c","asset":{"_ref":"image-b26bb6b76d862d4675ce82e0859f6fa9c2f67172-1203x547-jpg","_type":"reference"}}],"deadline":"2024-04-15","name":"Odeon site, Shaftesbury Ave","_id":"0799f739-9dff-4850-97f0-85f129c4330c","applicationNumber":"2024/0993/P","applicationStage":{"stage":"Consultation","status":{"assessment":"in progress","decision":"approved","appeal":"in progress","consultation":"in progress"}}}
```