### PR TITLE
DSNPI 1028 - WCAG pagination

### DIFF
--- a/src/components/govuk/Pagination/PageItem.tsx
+++ b/src/components/govuk/Pagination/PageItem.tsx
@@ -11,9 +11,7 @@ export interface PageItemProps {
 export const PageItem = ({ page, link, searchParams }: PageItemProps) => {
   return (
     <li
-      className={`govuk-pagination__item ${
-        page.current ? "govuk-pagination__item--current" : ""
-      } ${page.number === -1 ? "govuk-pagination__item--ellipses" : ""}`}
+      className={`govuk-pagination__item ${page.current ? "govuk-pagination__item--current" : ""} ${page.number === -1 ? "govuk-pagination__item--ellipses" : ""}`}
     >
       {page.number === -1 ? (
         <>&#x022EF;</>

--- a/src/components/govuk/Pagination/PageItem.tsx
+++ b/src/components/govuk/Pagination/PageItem.tsx
@@ -11,10 +11,12 @@ export interface PageItemProps {
 export const PageItem = ({ page, link, searchParams }: PageItemProps) => {
   return (
     <li
-      className={`govuk-pagination__item ${page.current ? "govuk-pagination__item--current" : ""} ${page.number === -1 ? "govuk-pagination__item--ellipses" : ""}`}
+      className={`govuk-pagination__item ${
+        page.current ? "govuk-pagination__item--current" : ""
+      } ${page.number === -1 ? "govuk-pagination__item--ellipses" : ""}`}
     >
       {page.number === -1 ? (
-        <>&sdot;&sdot;&sdot;</>
+        <>&#x022EF;</>
       ) : (
         <Link
           className="govuk-link govuk-pagination__link"


### PR DESCRIPTION
[Ticket 1028](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1028)

Replaces the `&sdot;` with `&#x022EF;` so that the ellipsis is read out by screenreaders