### PR TITLE
DSNPI 1057 - BUG - not populating env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Data is added manually using sanity studio
 
 #### OpenAPI
 
-Data is added by creating syncing with `NEXT_PUBLIC_API_URL`
+Data is added by creating syncing with `OPEN_API_URL`
 
 Simply add a valid Application Number to a planning application, scroll to Integrations and hit the Fetch from OpenAPI button. This then pulls in the following data: `application_type, name, development_address, development_description, location - latitude, longitude, applicationDocumentsUrl`. If the fields have a value it will display on Sanity.
 
@@ -183,9 +183,9 @@ You can provide config with a `.env` file. Run `cp sample.env .env` to create a 
 
 ### SANITY STUDIO
 
-| Variable              | Description                | Example   | Required?                                                |
-| --------------------- | -------------------------- | --------- | -------------------------------------------------------- |
-| `NEXT_PUBLIC_API_URL` | URL for public data source | `api-key` | Only if integrationMethod fetches data from a public api |
+| Variable       | Description                | Example   | Required?                                                |
+| -------------- | -------------------------- | --------- | -------------------------------------------------------- |
+| `OPEN_API_URL` | URL for public data source | `api-key` | Only if integrationMethod fetches data from a public api |
 
 ### SANITY
 

--- a/sample.env
+++ b/sample.env
@@ -18,7 +18,7 @@ GOOGLE_SERVICE_PRIVATE_KEY=
 
 # sets the url used for integrationMethod if its not manual or uniformAPI
 # eg https://opendata.camden.gov.uk/resource/2eiu-s2cw
-NEXT_PUBLIC_API_URL=
+OPEN_API_URL=
 
 # SANITY
 

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -77,3 +77,7 @@ export async function getLocationFromPostcode(postcode: string) {
   }
   return null;
 }
+
+export async function getOpenApiUrl() {
+  return process.env.OPEN_API_URL || "";
+}

--- a/src/components/populate-button/index.tsx
+++ b/src/components/populate-button/index.tsx
@@ -2,10 +2,12 @@
 import React, { useState, useEffect } from "react";
 import { useFormValue, useDocumentOperation } from "sanity";
 import { getGlobalContent } from "@/app/actions/sanityClient";
+import { getOpenApiUrl } from "@/app/actions/actions";
 
 export default function PopulateButton() {
   const [integrationMethod, setIntegrationMethod] = useState("");
   const [fetchStatus, setFetchStatus] = useState("idle");
+  const [apiUrl, setApiUrl] = useState("");
 
   useEffect(() => {
     const fetchGlobalContent = async () => {
@@ -19,6 +21,13 @@ export default function PopulateButton() {
     };
 
     fetchGlobalContent();
+
+    const fetchApiUrl = async () => {
+      const url = await getOpenApiUrl();
+      setApiUrl(url);
+    };
+
+    fetchApiUrl();
   }, []);
 
   const formId = useFormValue(["_id"]);
@@ -35,8 +44,14 @@ export default function PopulateButton() {
   const handlePopulate = async () => {
     setFetchStatus("idle");
     try {
+      if (!apiUrl) {
+        console.error("API URL is not available");
+        setFetchStatus("error");
+        return;
+      }
+
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL!}.json?$where=application_number='${applicationNumber}'`,
+        `${apiUrl}.json?$where=application_number='${applicationNumber}'`,
       );
       const data = await response.json();
 


### PR DESCRIPTION
:bug: [Ticket 1057](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1057) 🐛 

`NEXT_PUBLIC_API_URL` isn’t set at build time so when we fetch this value, the value is undefined.
We have now renamed `NEXT_PUBLIC_API_URL` to `OPEN_API_URL`, and created a server action `getOpenApiUrl()` which passes the value of our renamed env variable back to the `handlePopulate()` function.

Deployment env variables will need to be renamed too once this is deployed 🚀 