### PR TITLE
Accessibility fixes

### DIFF
--- a/src/components/comment/index.tsx
+++ b/src/components/comment/index.tsx
@@ -44,15 +44,17 @@ function CommentQuestion({
       setSelectedCheckbox(selectedCheckboxStorage?.value);
   }, []);
 
-  const onComment = (value: any) => {
-    setCommentForm({ ...commentForm, [question]: value });
+  const onComment = (value: string) => {
+    setCommentForm((prev) => ({ ...prev, [question]: value }));
     localStorage.setItem(
       "comment",
       JSON.stringify({ id, value: { ...commentForm, [question]: value } }),
     );
-    commentForm[question] !== "" && commentForm[question] !== undefined
-      ? setIsError(false)
-      : setIsError(true);
+    if (value.trim() !== "") {
+      setIsError(false);
+    } else {
+      setIsError(true);
+    }
   };
 
   function onNextPage() {

--- a/src/components/text-area/index.tsx
+++ b/src/components/text-area/index.tsx
@@ -13,11 +13,11 @@ const TextArea = ({
 }) => {
   return (
     <>
-      <h2 className="govuk-label-wrapper">
+      <h1 className="govuk-label-wrapper">
         <label className="govuk-label govuk-label--l" htmlFor={id}>
           {label}
         </label>
-      </h2>
+      </h1>
       {hint && <p className="govuk-hint">{hint}</p>}
       <textarea
         className={`govuk-textarea`}


### PR DESCRIPTION
- Change `<h2>` to `<h1>` on text area component.
- Fix text area validation bug by using immediate input value instead of potentially outdated state. Because state updates in React are asynchronous, that check was running before the new value was applied. This meant that even if you typed one character, `commentForm[question]` was still empty (or not updated yet), causing the validation error to trigger immediately.