### PR TITLE
Fix accessibility issue on form

### DIFF
--- a/__tests__/input.test.js
+++ b/__tests__/input.test.js
@@ -16,7 +16,9 @@ describe("Input", () => {
         autocomplete="postal-code"
       />,
     );
-    expect(screen.getByLabelText("Enter a postcode")).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", "Enter a postcode Optional"),
+    ).toBeInTheDocument();
   });
 
   it("should render hint when provided", () => {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -9,6 +9,7 @@ const Input = ({
   id,
   autocomplete,
   headingLevel,
+  required = false,
 }: {
   messageError?: string;
   isError?: boolean;
@@ -18,17 +19,19 @@ const Input = ({
   value?: string;
   type: string;
   id: string;
-  autocomplete: string;
+  autocomplete?: string;
   headingLevel?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  required: boolean;
 }) => {
   const HeadingTag = headingLevel || "div"; // Default to 'div' if no headingLevel is provided
 
-  const Label = () => (
+  const Label = ({ required = false }: { required: boolean }) => (
     <label
       className={`govuk-label ${headingLevel ? "govuk-label--l" : ""} ${isError ? "govuk-error-message" : ""}`}
       htmlFor={id}
     >
-      {label}
+      {label}{" "}
+      {!required && <span className="govuk-visually-hidden">Optional</span>}
     </label>
   );
 
@@ -38,10 +41,10 @@ const Input = ({
     >
       {headingLevel && (
         <HeadingTag className="govuk-label-wrapper">
-          <Label />
+          <Label required={required} />
         </HeadingTag>
       )}
-      {!headingLevel && <Label />}
+      {!headingLevel && <Label required={required} />}
       {hint && <div className="govuk-hint">{hint}</div>}
       {isError && <div className="govuk-error-message">{messageError}</div>}
       <input
@@ -52,6 +55,7 @@ const Input = ({
         onChange={(e) => onChange(e.target.value)}
         value={value}
         autoComplete={autocomplete}
+        required={required}
       />
     </div>
   );

--- a/src/components/personal-details/index.tsx
+++ b/src/components/personal-details/index.tsx
@@ -143,8 +143,9 @@ const PersonalDetails = ({
             type="text"
             isError={isNameError}
             messageError="Your name is required"
-            autocomplete="off"
+            autocomplete="name"
             id="name"
+            required={true}
           />
           <Input
             label="Address"
@@ -153,8 +154,9 @@ const PersonalDetails = ({
             type="text"
             isError={isAddressError}
             messageError="Your address is required"
-            autocomplete="off"
+            autocomplete="street-address"
             id="address"
+            required={true}
           />
           <Input
             label="Postcode"
@@ -163,8 +165,9 @@ const PersonalDetails = ({
             type="text"
             isError={isPostcodeError}
             messageError={`${personalDetailsForm?.postcode == "" ? "Your postcode is required" : "Invalid postcode"}`}
-            autocomplete="off"
+            autocomplete="postal-code"
             id="postcode"
+            required={true}
           />
           <Input
             label="Email address"
@@ -174,8 +177,9 @@ const PersonalDetails = ({
             type="email"
             isError={isEmailError}
             messageError="Invalid email"
-            autocomplete="off"
+            autocomplete="email"
             id="email"
+            required={false}
           />
           <Input
             label="Telephone number"
@@ -185,8 +189,9 @@ const PersonalDetails = ({
             type="tel"
             isError={isPhoneError}
             messageError="Invalid telephone number"
-            autocomplete="off"
+            autocomplete="tel"
             id="telephone"
+            required={false}
           />
 
           <div


### PR DESCRIPTION
Fixes the form accessibility error from the latest accessibility report

- Enables autocomplete on form inputs as recommended by govuk guidance
- Updates form input and textarea to use required attribute so screen readers and browsers can identify if a field is required or not
- Where a field is shown to be optional in the hint text add a visually hidden optional to the end of the label to make it clear to screen readers this is an optional field