### PR TITLE
Update API endpoints to return ID data

### DIFF
--- a/__tests__/api/application.test.ts
+++ b/__tests__/api/application.test.ts
@@ -89,6 +89,7 @@ describe("Applications PUT endpoint", () => {
       headers: {
         get: jest.fn().mockReturnValue("invalid_key"),
       },
+      json: jest.fn().mockResolvedValue("invalid_data"),
     } as unknown as NextRequest;
 
     isUniformIntegrationEnabledMock.mockResolvedValue(true);

--- a/__tests__/api/applications.test.ts
+++ b/__tests__/api/applications.test.ts
@@ -115,7 +115,7 @@ describe("Applications PUT endpoint", () => {
     expect(response.status).toBe(400);
   });
 
-  it("should return 207 for successful and failed applications", async () => {
+  it("should return 200 for successful and failed applications", async () => {
     const validApplication = generateUniformData();
     const invalidApplication = generateUniformData({
       applicationNumber: undefined,
@@ -148,6 +148,6 @@ describe("Applications PUT endpoint", () => {
 
     const response = (await PUT(mockRequest)) as NextResponse;
 
-    expect(response.status).toBe(207);
+    expect(response.status).toBe(200);
   });
 });

--- a/__tests__/api/checkAllowedUpdateFields.test.ts
+++ b/__tests__/api/checkAllowedUpdateFields.test.ts
@@ -99,14 +99,14 @@ describe("Application Handlers", () => {
       const result = await processApplication(minimalApplication);
 
       expect(createApplication).toHaveBeenCalledTimes(1);
-      expect(result.success).toContain("created");
+      expect(result.message).toContain("created");
     });
 
     it("creates new application with all fields", async () => {
       const result = await processApplication(validApplication);
 
       expect(createApplication).toHaveBeenCalledTimes(1);
-      expect(result.success).toContain("created");
+      expect(result.message).toContain("created");
     });
 
     it("updates existing application when changes detected", async () => {
@@ -124,7 +124,7 @@ describe("Application Handlers", () => {
       const result = await processApplication(newData);
 
       expect(updateApplication).toHaveBeenCalledTimes(1);
-      expect(result.success).toContain("updated");
+      expect(result.message).toContain("updated");
     });
 
     it("handles validation errors", async () => {
@@ -159,9 +159,11 @@ describe("Application Handlers", () => {
 
         const results = await processMultipleApplications(applications);
 
-        expect(results.success).toHaveLength(2);
+        const successfulUpdates = results.filter((result) => result.success);
+        const failedUpdates = results.filter((result) => !result.success);
+        expect(successfulUpdates).toHaveLength(2);
         expect(createApplication).toHaveBeenCalledTimes(2);
-        expect(results.errors).toHaveLength(0);
+        expect(failedUpdates).toHaveLength(0);
       });
 
       it("handles mix of successful and failed applications", async () => {
@@ -173,8 +175,10 @@ describe("Application Handlers", () => {
 
         const results = await processMultipleApplications(applications);
 
-        expect(results.success).toHaveLength(1);
-        expect(results.errors).toHaveLength(1);
+        const successfulUpdates = results.filter((result) => result.success);
+        const failedUpdates = results.filter((result) => !result.success);
+        expect(successfulUpdates).toHaveLength(1);
+        expect(failedUpdates).toHaveLength(1);
         expect(createApplication).toHaveBeenCalledTimes(1);
       });
 
@@ -188,16 +192,20 @@ describe("Application Handlers", () => {
 
         const results = await processMultipleApplications(applications);
 
-        expect(results.success).toHaveLength(0);
-        expect(results.errors).toHaveLength(2);
+        const successfulUpdates = results.filter((result) => result.success);
+        const failedUpdates = results.filter((result) => !result.success);
+        expect(successfulUpdates).toHaveLength(0);
+        expect(failedUpdates).toHaveLength(2);
         expect(createApplication).not.toHaveBeenCalled();
       });
 
       it("processes empty array", async () => {
         const results = await processMultipleApplications([]);
 
-        expect(results.success).toHaveLength(0);
-        expect(results.errors).toHaveLength(0);
+        const successfulUpdates = results.filter((result) => result.success);
+        const failedUpdates = results.filter((result) => !result.success);
+        expect(successfulUpdates).toHaveLength(0);
+        expect(failedUpdates).toHaveLength(0);
         expect(createApplication).not.toHaveBeenCalled();
       });
 
@@ -213,8 +221,10 @@ describe("Application Handlers", () => {
 
         const results = await processMultipleApplications(applications);
 
-        expect(results.success).toHaveLength(1);
-        expect(results.errors).toHaveLength(1);
+        const successfulUpdates = results.filter((result) => result.success);
+        const failedUpdates = results.filter((result) => !result.success);
+        expect(successfulUpdates).toHaveLength(1);
+        expect(failedUpdates).toHaveLength(1);
         expect(createApplication).toHaveBeenCalledTimes(2);
       });
     });

--- a/__tests__/api/handler.test.ts
+++ b/__tests__/api/handler.test.ts
@@ -57,14 +57,14 @@ describe("Application Handlers", () => {
       const result = await processApplication(minimalApplication);
 
       expect(createApplication).toHaveBeenCalledTimes(1);
-      expect(result.success).toContain("created");
+      expect(result.message).toContain("created");
     });
 
     it("creates new application with all fields", async () => {
       const result = await processApplication(validApplication);
 
       expect(createApplication).toHaveBeenCalledTimes(1);
-      expect(result.success).toContain("created");
+      expect(result.message).toContain("created");
     });
 
     it("updates existing application when changes detected", async () => {
@@ -82,7 +82,7 @@ describe("Application Handlers", () => {
       const result = await processApplication(newData);
 
       expect(updateApplication).toHaveBeenCalledTimes(1);
-      expect(result.success).toContain("updated");
+      expect(result.message).toContain("updated");
     });
 
     describe("Field-by-Field Update Tests", () => {
@@ -101,7 +101,7 @@ describe("Application Handlers", () => {
             isActive: validApplication.isActive,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
@@ -111,7 +111,7 @@ describe("Application Handlers", () => {
             isActive: !validApplication.isActive,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
           expect(updateApplication).toHaveBeenCalled();
         });
 
@@ -121,14 +121,14 @@ describe("Application Handlers", () => {
             planningId: validApplication.planningId,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
         it("detects changes in planningId", async () => {
           const updateData = { ...validApplication, planningId: "NEW123" };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
 
         it("detects no changes in address", async () => {
@@ -137,14 +137,14 @@ describe("Application Handlers", () => {
             address: validApplication.address,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
         it("detects changes in address", async () => {
           const updateData = { ...validApplication, address: "456 New Road" };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
       });
 
@@ -155,7 +155,7 @@ describe("Application Handlers", () => {
             location: { ...validApplication.location },
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
@@ -168,7 +168,7 @@ describe("Application Handlers", () => {
             },
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
 
         it("detects no changes in proposedLandUse", async () => {
@@ -177,7 +177,7 @@ describe("Application Handlers", () => {
             proposedLandUse: { ...validApplication.proposedLandUse },
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
@@ -189,7 +189,7 @@ describe("Application Handlers", () => {
             },
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
       });
 
@@ -199,7 +199,7 @@ describe("Application Handlers", () => {
             ...validApplication,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
@@ -213,7 +213,7 @@ describe("Application Handlers", () => {
             },
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
 
         it("detects no changes in carbonEmissions when showCarbon is true", async () => {
@@ -221,7 +221,7 @@ describe("Application Handlers", () => {
             ...validApplication,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
@@ -232,7 +232,7 @@ describe("Application Handlers", () => {
             carbonEmissions: 1,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
       });
 
@@ -244,7 +244,7 @@ describe("Application Handlers", () => {
             openSpaceArea: validApplication.openSpaceArea,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("no update needed");
+          expect(result.message).toContain("no update needed");
           expect(updateApplication).not.toHaveBeenCalled();
         });
 
@@ -254,7 +254,7 @@ describe("Application Handlers", () => {
             showOpenSpace: !validApplication.showOpenSpace,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
 
         it("detects changes in openSpaceArea when showOpenSpace is true", async () => {
@@ -264,7 +264,7 @@ describe("Application Handlers", () => {
             openSpaceArea: 1,
           };
           const result = await processApplication(updateData);
-          expect(result.success).toContain("updated");
+          expect(result.message).toContain("updated");
         });
       });
     });
@@ -284,7 +284,7 @@ describe("Application Handlers", () => {
       const result = await processApplication(updateData);
 
       expect(updateApplication).not.toHaveBeenCalled();
-      expect(result.success).toContain("no update needed");
+      expect(result.message).toContain("no update needed");
     });
 
     it("handles validation errors", async () => {
@@ -320,9 +320,11 @@ describe("Application Handlers", () => {
 
       const results = await processMultipleApplications(applications);
 
-      expect(results.success).toHaveLength(2);
+      const successfulUpdates = results.filter((result) => result.success);
+      const failedUpdates = results.filter((result) => !result.success);
+      expect(successfulUpdates).toHaveLength(2);
       expect(createApplication).toHaveBeenCalledTimes(2);
-      expect(results.errors).toHaveLength(0);
+      expect(failedUpdates).toHaveLength(0);
     });
 
     it("handles mix of successful and failed applications", async () => {
@@ -334,8 +336,10 @@ describe("Application Handlers", () => {
 
       const results = await processMultipleApplications(applications);
 
-      expect(results.success).toHaveLength(1);
-      expect(results.errors).toHaveLength(1);
+      const successfulUpdates = results.filter((result) => result.success);
+      const failedUpdates = results.filter((result) => !result.success);
+      expect(successfulUpdates).toHaveLength(1);
+      expect(failedUpdates).toHaveLength(1);
       expect(createApplication).toHaveBeenCalledTimes(1);
     });
 
@@ -349,16 +353,20 @@ describe("Application Handlers", () => {
 
       const results = await processMultipleApplications(applications);
 
-      expect(results.success).toHaveLength(0);
-      expect(results.errors).toHaveLength(2);
+      const successfulUpdates = results.filter((result) => result.success);
+      const failedUpdates = results.filter((result) => !result.success);
+      expect(successfulUpdates).toHaveLength(0);
+      expect(failedUpdates).toHaveLength(2);
       expect(createApplication).not.toHaveBeenCalled();
     });
 
     it("processes empty array", async () => {
       const results = await processMultipleApplications([]);
 
-      expect(results.success).toHaveLength(0);
-      expect(results.errors).toHaveLength(0);
+      const successfulUpdates = results.filter((result) => result.success);
+      const failedUpdates = results.filter((result) => !result.success);
+      expect(successfulUpdates).toHaveLength(0);
+      expect(failedUpdates).toHaveLength(0);
       expect(createApplication).not.toHaveBeenCalled();
     });
 
@@ -374,8 +382,10 @@ describe("Application Handlers", () => {
 
       const results = await processMultipleApplications(applications);
 
-      expect(results.success).toHaveLength(1);
-      expect(results.errors).toHaveLength(1);
+      const successfulUpdates = results.filter((result) => result.success);
+      const failedUpdates = results.filter((result) => !result.success);
+      expect(successfulUpdates).toHaveLength(1);
+      expect(failedUpdates).toHaveLength(1);
       expect(createApplication).toHaveBeenCalledTimes(2);
     });
   });


### PR DESCRIPTION
This PR updates the responses for the two endpoints `/api/application` and `/api/applications`

Previous responses were something like:

```json
{
  "data": {
    "success": [
      "1234/5678/A updated"
    ]
  }
}
```

or 

```json
{
  "data": {
    "success": [
      "Application 1234/5678/A no update needed",
      "Application 9876/5432/A updated"
    ]
  }
}
```


However this makes it difficult to easily generate something like the QR codes based off of a batch input when you can't easily tell what was/wasn't updated in your source data. 

This PR standardises all responses into 

```typescript
export interface ProcessApplicationResponse {
  _id: string | null;
  applicationNumber: string | null;
  planningId: string | null;
  success: boolean;
  message?: string;
  error?: string;
}
```

```json
{
  "_id": "abc12345cde",
  "applicationNumber": "1234/5678/A",
  "planningId": "123",
  "success": true,
  "message": "Planning application updated"
}
```

or 

```json
[
  {
    "_id": "abc12345cde",
    "applicationNumber": "1234/5678/A",
    "planningId": "123",
    "success": true,
    "message": "Planning application updated"
  },
  {
    "_id": "edc54321cba",
    "applicationNumber": "9876/5432/A",
    "planningId": "321",
    "success": false,
    "message": "Planning application not updated"
  }
]
```

This means that anyone using the API will be able to easily filter successful/errored responses from the results with result.successful, and know the new sanity id, and the planningId or applicationReference associated with it without additional work on their part. 

It also removes the 207 response if some are successful or not as its not recommended for REST API's. It will now return 200 if one or more is successful but if they all fail it will return 400.
