### PR TITLE
Add cms content styling css for wysiwyg 

### DIFF
--- a/src/app/(main)/cookie-policy/page.tsx
+++ b/src/app/(main)/cookie-policy/page.tsx
@@ -11,7 +11,7 @@ const CookiePolicyPage = async () => {
   return (
     <PageWrapper isCentered={true}>
       <h1 className="govuk-heading-l">Cookie Policy</h1>
-      <p className="govuk-body">{globalConfig?.cookiePolicyContent}</p>
+      <div className="dsn-content">{globalConfig?.cookiePolicyContent}</div>
     </PageWrapper>
   );
 };

--- a/src/styles/05-objects/_content.scss
+++ b/src/styles/05-objects/_content.scss
@@ -1,0 +1,37 @@
+/**
+Allows you to use html without govuk-frontend classes and still have styles
+*/
+
+.dsn-content {
+  @include govuk-global-styles;
+  // headings
+  h1 {
+    @extend %govuk-heading-m;
+  }
+  h2 {
+    @extend %govuk-heading-s;
+  }
+  h3 {
+    @extend %govuk-heading-s;
+  }
+  h4 {
+    @extend %govuk-heading-s;
+  }
+  h5 {
+    @extend %govuk-heading-s;
+  }
+  h6 {
+    @extend %govuk-heading-s;
+  }
+  // lists
+  ul,
+  ol {
+    @extend %govuk-list;
+  }
+  ul {
+    @extend %govuk-list--bullet;
+  }
+  ol {
+    @extend %govuk-list--number;
+  }
+}

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -14,6 +14,7 @@ $govuk-font-family: Arial, Helvetica, sans-serif;
 @import "./05-objects/details";
 @import "./05-objects/back-link";
 @import "./05-objects/button";
+@import "./05-objects/content";
 
 // 06-components
 @import "./06-components/header";


### PR DESCRIPTION
There is a chance we may need to support styling of html from sanity in the govuk styles. This PR adds in an object class which when applied as a parent will apply styling to some simple html tags in the govuk style.

Supported HTML

```html
<h1>header 1</h1>
<h2>header 2</h2>
<h3>header 3</h3>
<h4>header 4</h4>
<h5>header 5</h5>
<h6>header 6</h6>
<p>hello</p>

<ul>
  <li>hello</li>
</ul>

<ol>
  <li>hello</li>
</ol>

<p>
  hello <a href="#">link</a>
</p>
```

![image](https://github.com/user-attachments/assets/36a9ecd4-ec86-4ce9-bc94-b088f117fbe1)




---

In case we need it something like this can be used to support wysiwyg in sanity

```ts
    defineField({
      title: "Rich Text Content",
      name: "richTextContent",
      type: "array",
      of: [
        {
          type: "block",
          styles: [
            { title: "Normal", value: "normal" },
            { title: "Heading 1", value: "h1" },
            { title: "Heading 2", value: "h2" },
            { title: "Heading 3", value: "h3" },
            { title: "Quote", value: "blockquote" },
          ],
          lists: [
            { title: "Bullet", value: "bullet" },
            { title: "Numbered", value: "number" },
          ],
          marks: {
            decorators: [
              { title: "Strong", value: "strong" },
              { title: "Emphasis", value: "em" },
              { title: "Code", value: "code" },
            ],
            annotations: [
              {
                title: "URL",
                name: "link",
                type: "object",
                fields: [
                  {
                    title: "URL",
                    name: "href",
                    type: "url",
                  },
                ],
              },
            ],
          },
        },
      ],
    }),
```



