### PR TITLE
DSNPI-1216 & 1228  & 1237 / Cookie policy and updates to storing comment data

### DIFF
--- a/__tests__/components/feelings.test.js
+++ b/__tests__/components/feelings.test.js
@@ -15,6 +15,7 @@ beforeEach(() => {
 describe("Feeling component", () => {
   const mockOnChangeQuestion = jest.fn();
   const mockSetQuestion = jest.fn();
+  const mockApplicationId = "mockId";
 
   it("renders the component", () => {
     render(
@@ -32,6 +33,7 @@ describe("Feeling component", () => {
   it("displays an error message when Next button is clicked without selecting an option", () => {
     render(
       <Feeling
+        applicationId={mockApplicationId}
         onChangeQuestion={mockOnChangeQuestion}
         setQuestion={mockSetQuestion}
       />,

--- a/__tests__/components/topics.test.js
+++ b/__tests__/components/topics.test.js
@@ -10,21 +10,25 @@ describe("TopicsQuestion Component", () => {
   const mockOnChangeQuestion = jest.fn();
 
   beforeEach(() => {
-    // Clear mock localStorage before each test
-    localStorage.clear();
+    // Clear mock sessionStorage before each test
+    sessionStorage.clear();
 
-    // Mocking localStorage to return an array for 'topics'
+    // Mocking sessionStorage to return an array for 'topics'
     const mockTopicsStorage = JSON.stringify({
       id: "mockId",
       value: [], // Assuming initial state is an empty array, adjust as needed
     });
-    localStorage.setItem("topics", mockTopicsStorage);
-    localStorage.setItem("application", JSON.stringify({ _id: "mockId" }));
+    sessionStorage.setItem("topics_mockId", mockTopicsStorage);
+    sessionStorage.setItem(
+      "application_mockId",
+      JSON.stringify({ _id: "mockId" }),
+    );
   });
 
   const renderComponent = () =>
     render(
       <TopicsQuestion
+        applicationId="mockId"
         onChangeQuestion={mockOnChangeQuestion}
         setQuestion={mockSetQuestion}
       />,

--- a/__tests__/localstorage-validation.test.ts
+++ b/__tests__/localstorage-validation.test.ts
@@ -1,29 +1,36 @@
-import { getLocalStorage } from "../src/app/lib/application";
+import { getSessionStorage } from "../src/app/lib/application";
 
-describe("localstorage", () => {
+describe("sessionStorage", () => {
+  const mockApplicationId = "mockId";
   beforeAll(() => {
-    localStorage.clear();
-    localStorage.setItem("topics", JSON.stringify([1, 2, 3]));
-    localStorage.setItem("feelings", JSON.stringify(undefined));
+    sessionStorage.clear();
+    sessionStorage.setItem(
+      `topics_${mockApplicationId}`,
+      JSON.stringify([1, 2, 3]),
+    );
+    sessionStorage.setItem(
+      `feelings_${mockApplicationId}`,
+      JSON.stringify(undefined),
+    );
   });
 
   it("should return defaultValue", async () => {
-    const storage = getLocalStorage({
-      key: "feelings",
+    const storage = getSessionStorage({
+      key: `feelings_${mockApplicationId}`,
       defaultValue: {},
     });
     expect(storage).toEqual({});
   }),
     it("should return default when it's not storage", async () => {
-      const storage = getLocalStorage({
-        key: "comments",
+      const storage = getSessionStorage({
+        key: `comments_${mockApplicationId}`,
         defaultValue: {},
       });
       expect(storage).toEqual({});
     });
   it("should return some storage", async () => {
-    const storage = getLocalStorage({
-      key: "topics",
+    const storage = getSessionStorage({
+      key: `topics_${mockApplicationId}`,
       defaultValue: {},
     });
     expect(storage).toEqual([1, 2, 3]);

--- a/sanity/sanity.types.ts
+++ b/sanity/sanity.types.ts
@@ -76,7 +76,6 @@ export type GlobalContent = {
   integrations?: "manual" | "openAPI" | "uniformAPI";
   concernUrl?: string;
   concernContent?: string;
-  cookiePolicyContent?: string;
   feedbackUrl?: string;
   councilName?: string;
   signUpUrl?: string;

--- a/sanity/schemas/globalContent.ts
+++ b/sanity/schemas/globalContent.ts
@@ -37,11 +37,6 @@ export default defineType({
       type: "text",
     }),
     defineField({
-      title: "Cookie Policy Content",
-      name: "cookiePolicyContent",
-      type: "text",
-    }),
-    defineField({
       name: "feedbackUrl",
       title: "Feedback Url",
       type: "string",

--- a/src/app/(main)/cookie-policy/page.tsx
+++ b/src/app/(main)/cookie-policy/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unescaped-entities */
 import { getGlobalContent } from "@/app/actions/sanityClient";
 import PageWrapper from "@/components/pageWrapper";
 import { Metadata } from "next";
@@ -8,12 +9,283 @@ export const metadata: Metadata = {
 
 const CookiePolicyPage = async () => {
   const globalConfig: any = await getGlobalContent();
+  const enableComments = globalConfig?.globalEnableComments;
   return (
     <PageWrapper isCentered={true}>
-      <h1 className="govuk-heading-l">Cookie Policy</h1>
-      <p className="govuk-body">{globalConfig?.cookiePolicyContent}</p>
+      <CookiePolicyContent />
+      {enableComments && <CommentCookiePolicyContent />}
+      <AnalyticsPolicyConsent />
     </PageWrapper>
   );
 };
 
+const CookiePolicyContent = () => {
+  return (
+    <>
+      <h1 className="govuk-heading-l">Cookies</h1>
+      <h2 className="govuk-heading-m">What cookies are</h2>
+      <p className="govuk-body">
+        Cookies are small files saved on your phone, tablet or computer when you
+        visit a website.
+      </p>
+      <p className="govuk-body">
+        We use an essential cookie to keep your data secure while you use the
+        Digital Site Notice.
+      </p>
+      <h2 className="govuk-heading-m">Essential cookies</h2>
+      <p className="govuk-body">
+        Essential cookies keep your information secure while you use this
+        service. We do not need to ask permission to use essential cookies.
+      </p>
+      <p className="govuk-body">We use the following essential cookies:</p>
+      <table className="govuk-table govuk-table--small-text-until-tablet">
+        <thead className="govuk-table__head">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">
+              Name
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Purpose
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Expires
+            </th>
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              isConsentCookie
+            </th>
+            <td className="govuk-table__cell">
+              Stores your cookie preferences
+            </td>
+            <td className="govuk-table__cell">1 year</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 className="govuk-heading-m">Analytics cookies</h3>
+      <p className="govuk-body">
+        With your permission, we use Google Analytics to collect data about how
+        you use this service. This information helps us to improve our service.
+      </p>
+      <p className="govuk-body">
+        Google is not allowed to use or share our analytics data with anyone.
+      </p>
+      <p className="govuk-body">
+        Google Analytics store anonymised information about:
+      </p>
+      <table className="govuk-table govuk-table--small-text-until-tablet">
+        <thead className="govuk-table__head">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">
+              Name
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Purpose
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Expires
+            </th>
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              _ga
+            </th>
+            <td className="govuk-table__cell">Used to identify unique users</td>
+            <td className="govuk-table__cell">2 years</td>
+          </tr>
+        </tbody>
+      </table>
+    </>
+  );
+};
+
+const CommentCookiePolicyContent = () => {
+  return (
+    <>
+      <h2 className="govuk-heading-m">Essential session storage</h2>
+      <p className="govuk-body">
+        This service uses session storage to temporarily store small amounts of
+        data on your device. This helps the service work properly and improves
+        your experience as you move through the Digital Site Notice process.
+      </p>
+      <p className="govuk-body">Session storage:</p>
+      <ul className="govuk-list govuk-list--bullet">
+        <li>stores data only for the duration of your browser session</li>
+        <li>is deleted when you close your browser</li>
+        <li>is not accessible by other websites</li>
+        <li>does not automatically send data to our servers</li>
+      </ul>
+      <p className="govuk-body">We use the following session storage items:</p>
+      <table className="govuk-table govuk-table--small-text-until-tablet">
+        <thead className="govuk-table__head">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">
+              Name
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Purpose
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Expires
+            </th>
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              application
+            </th>
+            <td className="govuk-table__cell">
+              Stores the current planning application data.
+            </td>
+            <td className="govuk-table__cell">
+              When you submit a comment or close your browser.
+            </td>
+          </tr>
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              feeling
+            </th>
+            <td className="govuk-table__cell">
+              Stores what sentiment you selected about a planning application,
+              whether you are opposed, neutral or support it.
+            </td>
+            <td className="govuk-table__cell">
+              When you submit a comment or close your browser.
+            </td>
+          </tr>
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              topics
+            </th>
+            <td className="govuk-table__cell">
+              Stores which topics you selected to comment on, such as
+              &rsquo;Impacts on natural light&rsquo;, &rsquo;Noise from new
+              uses&rsquo;, etc
+            </td>
+            <td className="govuk-table__cell">
+              When you submit a comment or close your browser.
+            </td>
+          </tr>
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              comment
+            </th>
+            <td className="govuk-table__cell">
+              Stores the text you write about each topic in your comment.
+            </td>
+            <td className="govuk-table__cell">
+              When you submit a comment or close your browser.
+            </td>
+          </tr>
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              personalDetails
+            </th>
+            <td className="govuk-table__cell">
+              Stores the identifying information entered into the final step,
+              such as name, address and email.
+            </td>
+            <td className="govuk-table__cell">
+              When you submit a comment or close your browser.
+            </td>
+          </tr>
+
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              formId
+            </th>
+            <td className="govuk-table__cell">
+              A unique identifier generated at the time of submission to track
+              the form submission.
+            </td>
+            <td className="govuk-table__cell">
+              When you submit a comment or close your browser.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p className="govuk-body">
+        Note: Some session storage items may include additional identifying
+        information, such as the planning application reference number, to
+        manage multiple submissions.
+      </p>
+    </>
+  );
+};
+
+const AnalyticsPolicyConsent = () => {
+  return (
+    <>
+      <h2 className="govuk-heading-l">Analytics without cookies</h2>
+      <h3 className="govuk-heading-m">Digital Site Notice and Analytics</h3>
+      <p className="govuk-body">
+        We use a cookieless analytics tool to collect information about how
+        users interact with our website and services. This information is used
+        to improve our services and provide a better user experience.
+      </p>
+      <h3 className="govuk-heading-m"> What data is collected?</h3>
+      <p className="govuk-body">
+        The analytics tool collects data around user engagement including:
+      </p>
+      <ul className="govuk-list govuk-list--bullet">
+        <li className="govuk-body">Clicks on links and buttons</li>
+        <li className="govuk-body">
+          Scrolls and interactions with our website and services
+        </li>
+        <li className="govuk-body">
+          Device information, such as browser type and operating system
+        </li>
+      </ul>
+      <h3 className="govuk-heading-m"> What data is not collected?</h3>
+      <p className="govuk-body">
+        We do not collect any personal data through our analytics tool,
+        including:
+      </p>
+      <ul className="govuk-list govuk-list--bullet">
+        <li className="govuk-body">
+          Names, email addresses, or other contact information
+        </li>
+        <li className="govuk-body">
+          IP addresses or other identifying information inc Google cookie IDs
+        </li>
+        <li className="govuk-body">
+          Sensitive information, such as financial or health data
+        </li>
+      </ul>
+      <h3 className="govuk-heading-m">How is the data used?</h3>
+      <p className="govuk-body">
+        The data collected through our analytics tool is used to:
+      </p>
+      <ul className="govuk-list govuk-list--bullet">
+        <li className="govuk-body">
+          Improve the user experience and functionality of our website and
+          services
+        </li>
+        <li className="govuk-body">
+          Optimize our content and marketing efforts
+        </li>
+        <li className="govuk-body">
+          Analyse usage patterns and identify areas for improvement
+        </li>
+      </ul>
+      <h3 className="govuk-heading-m">How is the data stored and secured?</h3>
+      <p className="govuk-body">
+        The data collected through our analytics tool is stored securely and in
+        accordance with industry standards. We take appropriate measures to
+        ensure that the data is protected from unauthorized access, disclosure,
+        or use. We rely on terms and conditions of the analytics from Google.
+      </p>
+      <p className="govuk-body">
+        Cookieless information cannot be associated with any use, it is
+        unidentifiable, and therefore deletion or extraction cannot apply
+      </p>
+    </>
+  );
+};
 export default CookiePolicyPage;

--- a/src/app/(main)/planning-applications/[id]/feedback/instructions.tsx
+++ b/src/app/(main)/planning-applications/[id]/feedback/instructions.tsx
@@ -1,27 +1,27 @@
 /* eslint-disable react/no-unescaped-entities */
 "use client";
 import { useEffect, useState } from "react";
-import { getLocalStorage } from "../../../../lib/application";
+import { getSessionStorage } from "../../../../lib/application";
 import { getGlobalContent } from "../../../../actions/sanityClient";
 import { PlanningApplication } from "../../../../../../sanity/sanity.types";
 import CommentHead from "@/components/commentHead";
 import PageCenter from "@/components/pageCenter";
 
-function Instructions() {
+function Instructions({ applicationId }: { applicationId: string }) {
   const [application, setApplication] = useState<PlanningApplication>();
   const [councilName, setCouncilName] = useState();
 
   useEffect(() => {
     (async () => {
       const globalConfig: any = await getGlobalContent();
-      const getStorage = getLocalStorage({
-        key: "application",
+      const getStorage = getSessionStorage({
+        key: `application_${applicationId}`,
         defaultValue: {},
       });
       setApplication(getStorage);
       setCouncilName(globalConfig?.councilName);
     })();
-  }, []);
+  }, [applicationId]);
 
   return (
     <div className="dsn-impact">

--- a/src/app/(main)/planning-applications/[id]/feedback/page.tsx
+++ b/src/app/(main)/planning-applications/[id]/feedback/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import Instructions from "./instructions";
 import Questions from "../../../../../components/questions";
-import { getLocalStorage } from "../../../../lib/application";
+import { getSessionStorage } from "../../../../lib/application";
 import { PlanningApplication } from "../../../../../../sanity/sanity.types";
 import { getGlobalContent } from "@/app/actions/sanityClient";
 import { useRouter } from "next/navigation";
@@ -21,8 +21,8 @@ const Feedback = ({ params }: { params: { id: string } }) => {
   useEffect(() => {
     const initializePage = async () => {
       const globalConfig = await getGlobalContent();
-      const storedApplication = getLocalStorage({
-        key: "application",
+      const storedApplication = getSessionStorage({
+        key: `application_${applicationId}`,
         defaultValue: {},
       });
 
@@ -51,8 +51,8 @@ const Feedback = ({ params }: { params: { id: string } }) => {
   }, [router, applicationId]);
 
   const onChangeQuestion = () => {
-    const getStorageSelectedCheckbox = getLocalStorage({
-      key: "topics",
+    const getStorageSelectedCheckbox = getSessionStorage({
+      key: `topics_${applicationId}`,
       defaultValue: [],
     });
     const selectedCheckbox =
@@ -85,12 +85,15 @@ const Feedback = ({ params }: { params: { id: string } }) => {
 
   return (
     <PageWrapper isCentered={false}>
-      {question !== 0 && question !== 13 && <Instructions />}
+      {question !== 0 && question !== 13 && (
+        <Instructions applicationId={applicationId} />
+      )}
       <PageCenter>
         <Questions
           question={question}
           onChangeQuestion={() => onChangeQuestion()}
           setQuestion={setQuestion}
+          applicationId={applicationId}
         />
       </PageCenter>
     </PageWrapper>

--- a/src/app/(main)/planning-applications/[id]/page.tsx
+++ b/src/app/(main)/planning-applications/[id]/page.tsx
@@ -36,7 +36,7 @@ const PlanningApplicationItem = async ({ params }: HomeProps) => {
         />
       </div>
       <PageWrapper isCentered={false}>
-        <About data={application} />
+        <About data={application} applicationId={params.id} />
         <Impact data={application} />
         <hr className="govuk-section-break govuk-section-break--l" />
         <Process data={application} />

--- a/src/app/(main)/planning-applications/[id]/thank-you/page.tsx
+++ b/src/app/(main)/planning-applications/[id]/thank-you/page.tsx
@@ -3,13 +3,13 @@
 import Link from "next/link";
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import { getLocalStorage } from "../../../../lib/application";
+import { getSessionStorage } from "../../../../lib/application";
 import { getGlobalContent, urlFor } from "../../../../actions/sanityClient";
 import { PlanningApplication } from "../../../../../../sanity/sanity.types";
 import CommentHead from "@/components/commentHead";
 import PageWrapper from "@/components/pageWrapper";
 
-const FeedbackMessage = () => {
+const FeedbackMessage = ({ applicationId }: { applicationId: string }) => {
   const [globalConfig, setGlobalConfig] = useState<any>();
   const [application, setAplication] = useState<PlanningApplication>();
   const [formId, setFormId] = useState<string | null>();
@@ -18,16 +18,16 @@ const FeedbackMessage = () => {
     (async () => {
       const fetchGlobalConfig: any = await getGlobalContent();
       setGlobalConfig(fetchGlobalConfig);
-      const initialValue = getLocalStorage({
-        key: "application",
+      const initialValue = getSessionStorage({
+        key: `application_${applicationId}`,
         defaultValue: {},
       });
       setAplication(initialValue);
 
-      const formId = localStorage.getItem("formId");
+      const formId = sessionStorage.getItem(`formId_${applicationId}`);
       setFormId(formId);
     })();
-  }, []);
+  }, [applicationId]);
 
   return (
     <PageWrapper isCentered={true}>

--- a/src/app/actions/actions.ts
+++ b/src/app/actions/actions.ts
@@ -8,7 +8,11 @@ import { cookies } from "next/headers";
 export async function createCookies(value: any) {
   const cookieStore = cookies();
   cookieStore.set("isShowCookie", "false"),
-    cookieStore.set("isConsentCookie", value);
+    cookieStore.set("isConsentCookie", value.toString(), {
+      path: "/",
+      maxAge: 31536000,
+      sameSite: "strict",
+    });
 }
 
 export async function saveComments(data: any) {

--- a/src/app/lib/application.tsx
+++ b/src/app/lib/application.tsx
@@ -14,8 +14,8 @@ export const phoneRegex =
 export const postCodeRegex =
   /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/;
 
-export function getLocalStorage({ key, defaultValue }: any) {
-  const getValue = localStorage.getItem(key);
+export function getSessionStorage({ key, defaultValue }: any) {
+  const getValue = sessionStorage.getItem(key);
 
   let storagedValue = defaultValue;
 

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -9,7 +9,13 @@ import PageCenter from "../pageCenter";
 import ButtonStart from "../buttonStart";
 import ImageGallery from "../imageGallery";
 
-function About({ data }: { data: PlanningApplication }) {
+function About({
+  data,
+  applicationId,
+}: {
+  data: PlanningApplication;
+  applicationId: string;
+}) {
   const [globalConfig, setGlobalConfig] = useState<any>();
 
   useEffect(() => {
@@ -20,8 +26,8 @@ function About({ data }: { data: PlanningApplication }) {
   }, []);
 
   useEffect(() => {
-    localStorage.setItem(
-      "application",
+    sessionStorage.setItem(
+      `application_${applicationId}`,
       JSON.stringify({
         address: data?.address,
         image_head: data?.image_head,
@@ -34,7 +40,7 @@ function About({ data }: { data: PlanningApplication }) {
         applicationUpdatesUrl: data?.applicationUpdatesUrl,
       }),
     );
-  }, [data]);
+  }, [data, applicationId]);
 
   let galleryImages = data.image_head ? [data.image_head] : [];
 

--- a/src/components/check-answers/index.tsx
+++ b/src/components/check-answers/index.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { BackLink, Button, ButtonLink } from "@/components/button";
 import Details from "@/components/details";
-import { questions, getLocalStorage } from "@/app/lib/application";
+import { questions, getSessionStorage } from "@/app/lib/application";
 import { descriptionDetail } from "@/app/lib/description";
 import { useRouter } from "next/navigation";
 import { PersonalDetailsForm, CommentForm } from "@/app/lib/type";
@@ -11,9 +11,11 @@ import { saveComments } from "@/app/actions/actions";
 export const questionId: number[] = [3, 4, 5, 6, 7, 8, 9, 10];
 
 function CheckAnswers({
+  applicationId,
   onChangeQuestion,
   setQuestion,
 }: {
+  applicationId: string;
   onChangeQuestion: () => void;
   setQuestion: (value: number) => void;
 }) {
@@ -34,32 +36,32 @@ function CheckAnswers({
   const router = useRouter();
 
   useEffect(() => {
-    const applicationStorage = getLocalStorage({
-      key: "application",
+    const applicationStorage = getSessionStorage({
+      key: `application_${applicationId}`,
       defaultValue: {},
     });
 
     setId(applicationStorage?._id);
 
-    const initialPersonalDetails = getLocalStorage({
-      key: "personalDetails",
+    const initialPersonalDetails = getSessionStorage({
+      key: `personalDetails_${applicationId}`,
       defaultValue: {},
     });
     initialPersonalDetails?.id === applicationStorage?._id &&
       setPersonalDetailsForm(initialPersonalDetails?.value);
 
-    const initialValueComment = getLocalStorage({
-      key: "comment",
+    const initialValueComment = getSessionStorage({
+      key: `comment_${applicationId}`,
       defaultValue: {},
     });
 
-    const initialValueCheckbox = getLocalStorage({
-      key: "topics",
+    const initialValueCheckbox = getSessionStorage({
+      key: `topics_${applicationId}`,
       defaultValue: {},
     });
 
-    const initialValueFeeling = getLocalStorage({
-      key: "feeling",
+    const initialValueFeeling = getSessionStorage({
+      key: `feeling_${applicationId}`,
       defaultValue: {},
     });
     initialValueCheckbox?.id === applicationStorage?._id &&
@@ -79,8 +81,8 @@ function CheckAnswers({
     } else {
       setQuestion(label);
       setSelectedCheckbox([...selectedCheckbox, label]);
-      localStorage.setItem(
-        "topics",
+      sessionStorage.setItem(
+        `topics_${applicationId}`,
         JSON.stringify({ id, value: [...selectedCheckbox, label] }),
       );
     }
@@ -94,7 +96,7 @@ function CheckAnswers({
     // });
 
     let formId = crypto.randomUUID();
-    localStorage.setItem("formId", formId);
+    sessionStorage.setItem(`formId_${applicationId}`, formId);
 
     let topics: any = [];
     let comment: any = {};
@@ -103,8 +105,8 @@ function CheckAnswers({
       topics.push(questions[el]);
       comment = { ...comment, [questions[el]]: commentForm[el] };
     });
-    const application = getLocalStorage({
-      key: "application",
+    const application = getSessionStorage({
+      key: `application_${applicationId}`,
       defaultValue: {},
     });
     const applicationNumber = application?.applicationNumber;
@@ -122,10 +124,10 @@ function CheckAnswers({
       if (response.ok) {
         onChangeQuestion();
         router.push(`/planning-applications/${id}/thank-you`);
-        localStorage.removeItem("feeling");
-        localStorage.removeItem("topics");
-        localStorage.removeItem("comment");
-        localStorage.removeItem("personalDetails");
+        sessionStorage.removeItem(`feeling_${applicationId}`);
+        sessionStorage.removeItem(`topics_${applicationId}`);
+        sessionStorage.removeItem(`comment_${applicationId}`);
+        sessionStorage.removeItem(`personalDetails_${applicationId}`);
       } else {
         console.log("Error fetching data");
       }

--- a/src/components/comment/index.tsx
+++ b/src/components/comment/index.tsx
@@ -3,14 +3,16 @@ import TextArea from "@/components/text-area";
 import Validation from "@/components/validation";
 import { Button, BackLink } from "@/components/button";
 import { questions } from "@/app/lib/application";
-import { getLocalStorage } from "@/app/lib/application";
+import { getSessionStorage } from "@/app/lib/application";
 import { CommentForm } from "@/app/lib/type";
 
 function CommentQuestion({
+  applicationId,
   onChangeQuestion,
   setQuestion,
   question,
 }: {
+  applicationId: string;
   onChangeQuestion: () => void;
   setQuestion: (value: number) => void;
   question: number;
@@ -25,16 +27,16 @@ function CommentQuestion({
   const label = questions[question];
 
   useEffect(() => {
-    const commentStorage = getLocalStorage({
-      key: "comment",
+    const commentStorage = getSessionStorage({
+      key: `comment_${applicationId}`,
       defaultValue: {},
     });
-    const selectedCheckboxStorage = getLocalStorage({
-      key: "topics",
+    const selectedCheckboxStorage = getSessionStorage({
+      key: `topics_${applicationId}`,
       defaultValue: {},
     });
-    const applicationStorage = getLocalStorage({
-      key: "application",
+    const applicationStorage = getSessionStorage({
+      key: `application_${applicationId}`,
       defaultValue: {},
     });
     setId(applicationStorage?._id);
@@ -42,12 +44,12 @@ function CommentQuestion({
       setCommentForm(commentStorage?.value);
     selectedCheckboxStorage?.id == applicationStorage?._id &&
       setSelectedCheckbox(selectedCheckboxStorage?.value);
-  }, []);
+  }, [applicationId]);
 
   const onComment = (value: string) => {
     setCommentForm((prev) => ({ ...prev, [question]: value }));
-    localStorage.setItem(
-      "comment",
+    sessionStorage.setItem(
+      `comment_${applicationId}`,
       JSON.stringify({ id, value: { ...commentForm, [question]: value } }),
     );
     if (value.trim() !== "") {

--- a/src/components/feedback-information/index.tsx
+++ b/src/components/feedback-information/index.tsx
@@ -3,14 +3,16 @@
 import Link from "next/link";
 import { BackLink, Button } from "@/components/button";
 import { useEffect, useState } from "react";
-import { getLocalStorage } from "@/app/lib/application";
+import { getSessionStorage } from "@/app/lib/application";
 import { getGlobalContent } from "@/app/actions/sanityClient";
 import { useRouter } from "next/navigation";
 import ButtonStart from "../buttonStart";
 
 function FeedbackInformation({
+  applicationId,
   onChangeQuestion,
 }: {
+  applicationId: string;
   onChangeQuestion: () => void;
 }) {
   const [globalConfig, setGlobalConfig] = useState<any>();
@@ -28,14 +30,14 @@ function FeedbackInformation({
           : fetchGlobalConfig?.concernContent && "/concern-info",
       );
 
-      const applicationContent = getLocalStorage({
-        key: "application",
+      const applicationContent = getSessionStorage({
+        key: `application_${applicationId}`,
         defaultValue: {},
       });
-      localStorage.removeItem("formId");
+      sessionStorage.removeItem(`formId_${applicationId}`);
       setId(applicationContent?._id);
     })();
-  }, []);
+  }, [applicationId]);
 
   return (
     <>

--- a/src/components/feelings/index.tsx
+++ b/src/components/feelings/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button, BackLink } from "@/components/button";
-import { getLocalStorage } from "@/app/lib/application";
+import { getSessionStorage } from "@/app/lib/application";
 
 const Radio = ({
   fieldName,
@@ -37,18 +37,20 @@ const Radio = ({
 const options = ["Opposed", "Neutral", "Support"];
 
 function Feeling({
+  applicationId,
   onChangeQuestion,
   setQuestion,
 }: {
+  applicationId: string;
   onChangeQuestion: () => void;
   setQuestion: (value: number) => void;
 }) {
-  const applicationStorage = getLocalStorage({
-    key: "application",
+  const applicationStorage = getSessionStorage({
+    key: `application_${applicationId}`,
     defaultValue: {},
   });
-  const feelingStorage = getLocalStorage({
-    key: "feeling",
+  const feelingStorage = getSessionStorage({
+    key: `feeling_${applicationId}`,
     defaultValue: undefined,
   });
 
@@ -61,7 +63,10 @@ function Feeling({
   const selectSentiment = (value: string) => {
     setSentiment(value);
     setIsError(false);
-    localStorage.setItem("feeling", JSON.stringify({ id, value }));
+    sessionStorage.setItem(
+      `feeling_${applicationId}`,
+      JSON.stringify({ id, value }),
+    );
   };
 
   return (

--- a/src/components/personal-details/index.tsx
+++ b/src/components/personal-details/index.tsx
@@ -18,13 +18,15 @@ import {
   postcodeValidation,
 } from "../../app/lib/feedback-validation";
 import { PersonalDetailsForm } from "../../app/lib/type";
-import { getLocalStorage } from "../../app/lib/application";
+import { getSessionStorage } from "../../app/lib/application";
 import { getGlobalContent } from "../../app/actions/sanityClient";
 
 const PersonalDetails = ({
+  applicationId,
   onChangeQuestion,
   setQuestion,
 }: {
+  applicationId: string;
   onChangeQuestion: () => void;
   setQuestion: (value: number) => void;
 }) => {
@@ -62,32 +64,32 @@ const PersonalDetails = ({
       const fetchGlobalConfig: any = await getGlobalContent();
       setGlobalConfig(fetchGlobalConfig);
 
-      const applicationStorage = getLocalStorage({
-        key: "application",
+      const applicationStorage = getSessionStorage({
+        key: `application_${applicationId}`,
         defaultValue: {},
       });
       setId(applicationStorage?._id);
 
-      const personalDetailsStorage = getLocalStorage({
-        key: "personalDetails",
+      const personalDetailsStorage = getSessionStorage({
+        key: `personalDetails_${applicationId}`,
         defaultValue: {},
       });
       personalDetailsStorage?.id === applicationStorage?._id &&
         setPersonalDetailsForm(personalDetailsStorage?.value);
 
-      const selectedCheckboxStorage = getLocalStorage({
-        key: "topics",
+      const selectedCheckboxStorage = getSessionStorage({
+        key: `topics_${applicationId}`,
         defaultValue: {},
       });
       selectedCheckboxStorage?.id === applicationStorage?._id &&
         setSelectedCheckbox(selectedCheckboxStorage?.value);
     })();
-  }, []);
+  }, [applicationId]);
 
   const onChangeDetails = (value: any, key: string) => {
     setPersonalDetailsForm({ ...personalDetailsForm, [key]: value });
-    localStorage.setItem(
-      "personalDetails",
+    sessionStorage.setItem(
+      `personalDetails_${applicationId}`,
       JSON.stringify({ id, value: { ...personalDetailsForm, [key]: value } }),
     );
   };

--- a/src/components/questions/index.tsx
+++ b/src/components/questions/index.tsx
@@ -9,18 +9,26 @@ const FeedbackQuestions = ({
   question,
   onChangeQuestion,
   setQuestion,
+  applicationId,
 }: {
   question: number;
   onChangeQuestion: () => void;
   setQuestion: (value: number) => void;
+  applicationId: string;
 }) => {
   const switchComponent = () => {
     switch (question) {
       case 0:
-        return <FeedbackInformation onChangeQuestion={onChangeQuestion} />;
+        return (
+          <FeedbackInformation
+            applicationId={applicationId}
+            onChangeQuestion={onChangeQuestion}
+          />
+        );
       case 1:
         return (
           <Feeling
+            applicationId={applicationId}
             onChangeQuestion={onChangeQuestion}
             setQuestion={setQuestion}
           />
@@ -28,6 +36,7 @@ const FeedbackQuestions = ({
       case 2:
         return (
           <Topics
+            applicationId={applicationId}
             onChangeQuestion={onChangeQuestion}
             setQuestion={setQuestion}
           />
@@ -35,6 +44,7 @@ const FeedbackQuestions = ({
       case 11:
         return (
           <PersonalDetails
+            applicationId={applicationId}
             onChangeQuestion={onChangeQuestion}
             setQuestion={setQuestion}
           />
@@ -42,6 +52,7 @@ const FeedbackQuestions = ({
       case 12:
         return (
           <CheckAnswers
+            applicationId={applicationId}
             onChangeQuestion={onChangeQuestion}
             setQuestion={setQuestion}
           />
@@ -51,6 +62,7 @@ const FeedbackQuestions = ({
       default:
         return (
           <Comment
+            applicationId={applicationId}
             onChangeQuestion={onChangeQuestion}
             setQuestion={setQuestion}
             question={question}

--- a/src/components/topics/index.tsx
+++ b/src/components/topics/index.tsx
@@ -5,14 +5,16 @@ import Details from "@/components/details";
 import Validation from "@/components/validation";
 import { descriptionDetail } from "@/app/lib/description";
 import { questions } from "@/app/lib/application";
-import { getLocalStorage } from "@/app/lib/application";
+import { getSessionStorage } from "@/app/lib/application";
 
 export const checkboxId: number[] = [3, 4, 5, 6, 7, 8, 9, 10];
 
 const TopicsQuestion = ({
+  applicationId,
   onChangeQuestion,
   setQuestion,
 }: {
+  applicationId: string;
   onChangeQuestion: () => void;
   setQuestion: (value: number) => void;
 }) => {
@@ -21,26 +23,26 @@ const TopicsQuestion = ({
   const [idApplication, setId] = useState();
 
   useEffect(() => {
-    const getStorage = getLocalStorage({
-      key: "topics",
+    const getStorage = getSessionStorage({
+      key: `topics_${applicationId}`,
       defaultValue: {},
     });
-    const applicationStorage = getLocalStorage({
-      key: "application",
+    const applicationStorage = getSessionStorage({
+      key: `application_${applicationId}`,
       defaultValue: {},
     });
 
     setId(applicationStorage?._id);
     getStorage?.id === applicationStorage?._id &&
       setSelectedCheckbox(getStorage.value);
-  }, [setSelectedCheckbox]);
+  }, [setSelectedCheckbox, applicationId]);
 
   const onChecked = (e: any) => {
     const { id, checked } = e.target;
     checked
       ? (setSelectedCheckbox([...selectedCheckbox, parseInt(id)]),
-        localStorage.setItem(
-          "topics",
+        sessionStorage.setItem(
+          `topics_${applicationId}`,
           JSON.stringify({
             id: idApplication,
             value: [...selectedCheckbox, parseInt(id)],
@@ -49,8 +51,8 @@ const TopicsQuestion = ({
       : (setSelectedCheckbox([
           ...selectedCheckbox?.filter((el) => el !== parseInt(id)),
         ]),
-        localStorage.setItem(
-          "topics",
+        sessionStorage.setItem(
+          `topics_${applicationId}`,
           JSON.stringify({
             id: idApplication,
             value: [...selectedCheckbox?.filter((el) => el !== parseInt(id))],


### PR DESCRIPTION
[Ticket 1216](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1216)
[Ticket 1228](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1228)
[Ticket 1237](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1237)

This PR adds the cookie policy page to the DSN. It is similar to the DPR policy but with changes that are specific to the DSN. We also refactor the comment storage to use session storage instead of local storage.


Changes:
- Adds cookie policy content and conditionally display the comment cookies information if comments are enabled in Sanity. 
- Removes cookie content field from Sanity backend.
- Sets expiry for the consent cookie (1 year).
- Changes local storage to session storage for storing comment data, to ensure comment data is not persisted once the tab/browser is closed.
- Adds the planning id found in the params to each individual session storage item we set. This means that if a user enters some comment data, but doesn't complete the comment journey to submission, then goes to another application to comment, the values won't be retained on the new comment journey.

![image](https://github.com/user-attachments/assets/81c752bc-309e-42de-838e-3a4087d32f85)



