### PR TITLE
DSNPI - 1238/order applications from newest to oldest

### DIFF
--- a/src/app/actions/sanityClient.ts
+++ b/src/app/actions/sanityClient.ts
@@ -67,7 +67,7 @@ export async function getActiveApplications(
 ): Promise<sanityApplicationResponse> {
   try {
     const query = `{
-        "results": *[_type == "planning-application" && isActive == true ${requiredFields} && !(_id in path("drafts.**"))] | order(_id) 
+        "results": *[_type == "planning-application" && isActive == true ${requiredFields} && !(_id in path("drafts.**"))] | order(_createdAt desc)
           ${itemsPerPage ? `[${offSet}...${offSet + itemsPerPage}]` : ""} {
             _id, 
             image_head, 


### PR DESCRIPTION
[Ticket 1238](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1238)

This PR changes the default ordering from ordering by ID to ordering by _createdAt descending. This does not affect the ordering of applications when performing a postcode search, as that orders by postcode proximity.