### PR TITLE
DSNPI-68 Restrict max image size on site

### DIFF
--- a/src/components/commentHead/index.tsx
+++ b/src/components/commentHead/index.tsx
@@ -18,7 +18,7 @@ const CommentHead = ({
           className="dsn-comment-head__image"
           style={{
             backgroundImage: application?.image_head
-              ? `url(${urlFor(application?.image_head).url()})`
+              ? `url(${urlFor(application?.image_head).width(200).url()})`
               : "none",
           }}
         ></div>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -13,7 +13,11 @@ const Header = ({ globalConfig }: any) => {
                 width={100}
                 height={35}
                 alt={`${globalConfig?.councilName} Council`}
-                src={urlFor(globalConfig?.logo)?.url()}
+                src={urlFor(globalConfig?.logo)
+                  ?.height(35)
+                  .width(100)
+                  .fit("max")
+                  .url()}
               />
             </Link>
           </div>

--- a/src/components/imageGallery/index.tsx
+++ b/src/components/imageGallery/index.tsx
@@ -91,7 +91,7 @@ const ImageGallery = ({
             className="dpr-gallery__lightbox-image"
             style={{
               backgroundImage: images[selectedImage]
-                ? `url(${urlFor(images[selectedImage]).url()})`
+                ? `url(${urlFor(images[selectedImage]).width(1024).height(768).ignoreImageParams().fit("fillmax").bg("f3f2f1").url()})`
                 : "none",
             }}
           ></div>
@@ -131,7 +131,7 @@ const ImageGallery = ({
         id="current-image"
         style={{
           backgroundImage: images[selectedImage]
-            ? `url(${urlFor(images[selectedImage]).url()})`
+            ? `url(${urlFor(images[selectedImage]).width(385).height(270).ignoreImageParams().fit("fillmax").bg("f3f2f1").url()})`
             : "none",
         }}
       >
@@ -153,7 +153,7 @@ const ImageGallery = ({
             title={`Click to show image number ${index + 1}`}
             style={{
               backgroundImage: images[index]
-                ? `url(${urlFor(images[index]).url()})`
+                ? `url(${urlFor(images[index]).width(110).height(77).ignoreImageParams().fit("fillmax").bg("f3f2f1").url()})`
                 : "none",
             }}
           >

--- a/src/components/planning-application-list/index.tsx
+++ b/src/components/planning-application-list/index.tsx
@@ -36,7 +36,7 @@ const PlanningApplicationList = ({ data }: { data: PlanningApplication[] }) => {
                   className="dsn-planning-application-card__image"
                   style={{
                     backgroundImage: image_head
-                      ? `url(${urlFor(image_head).url()})`
+                      ? `url(${urlFor(image_head).height(223).url()})`
                       : "none",
                   }}
                 ></div>

--- a/src/styles/06-components/_image-gallery.scss
+++ b/src/styles/06-components/_image-gallery.scss
@@ -38,7 +38,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 
   &__lightbox-image {
     background-color: govuk-colour("light-grey");
-    background-size: cover;
+    background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
     width: 85vw;


### PR DESCRIPTION
[DSNPI-68](https://tpximpact.atlassian.net/browse/DSNPI-68)

Found this in the backlog - super quick fix and worth doing since we're on the free plan!

Uses the [image url](https://github.com/sanity-io/image-url) properties to stop massive images being loaded. Also maintains aspect ratio for images. 


From:

![image](https://github.com/user-attachments/assets/9fd4c115-4ca7-4004-ad48-af448bcf2fcb)


To:

![image](https://github.com/user-attachments/assets/e22e2da9-41aa-4902-a8dc-1ebba12898ea)

---

From:

![image](https://github.com/user-attachments/assets/a28b39aa-8848-4d07-9794-da898416775d)
![image](https://github.com/user-attachments/assets/e90614c7-0b72-48d8-b110-4886f3f3afa7)


To:

![image](https://github.com/user-attachments/assets/7e54bbe2-81ef-47d6-afc9-6dfc14434a3e)
![image](https://github.com/user-attachments/assets/3729db3e-2000-4177-9066-cc333d74340a)

---


From:

![image](https://github.com/user-attachments/assets/48d6e0a8-cbcf-4a56-82be-94819c866bc8)


To:

![image](https://github.com/user-attachments/assets/c574b6a8-4e8a-4960-bd09-6f2467d42e1a)


