### PR TITLE
split id from planningId query

### DIFF
--- a/__tests__/actions/sanityClient.test.ts
+++ b/__tests__/actions/sanityClient.test.ts
@@ -1,6 +1,5 @@
 import {
   getActiveApplications,
-  getActiveApplicationById,
   getActiveApplicationsByLocation,
   getGlobalContent,
   getApplicationByApplicationNumber,
@@ -8,6 +7,8 @@ import {
   updateApplication,
   sanityFetch,
   clientWithToken,
+  getActiveApplicationByPlanningId,
+  getActiveApplicationBySanityId,
 } from "@/actions/sanityClient";
 
 jest.mock("@/sanity/lib/client", () => ({
@@ -61,15 +62,29 @@ describe("sanityClient actions", () => {
     });
   });
 
-  describe("getActiveApplicationById", () => {
+  describe("getActiveApplicationBySanityId", () => {
     it("fetches by id", async () => {
       mockClient.fetch.mockResolvedValue({ _id: "id1" });
-      const result = await getActiveApplicationById("id1");
+      const result = await getActiveApplicationBySanityId("id1");
       expect(mockClient.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("$_id in [_id, planningId]"),
+        expect.stringContaining("$_id == _id"),
         { _id: "id1" },
       );
       expect(result).toEqual({ _id: "id1" });
+    });
+  });
+
+  describe("getActiveApplicationByPlanningId", () => {
+    it("fetches by id", async () => {
+      mockClient.fetch.mockResolvedValue({ _id: "1234-1234-1234-1234" });
+      const result = await getActiveApplicationByPlanningId(
+        "1234-1234-1234-1234",
+      );
+      expect(mockClient.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("$_id == planningId"),
+        { _id: "1234-1234-1234-1234" },
+      );
+      expect(result).toEqual({ _id: "1234-1234-1234-1234" });
     });
   });
 

--- a/src/actions/sanityClient.ts
+++ b/src/actions/sanityClient.ts
@@ -1,5 +1,6 @@
 import { client } from "@/sanity/lib/client";
 import { PlanningApplication } from "@/sanity/types";
+import { IntegrationMethod } from "@/types";
 
 const SECRET_TOKEN = process.env.SANITY_SECRET_TOKEN;
 
@@ -70,12 +71,47 @@ export async function getActiveApplications(
 }
 
 /**
- * Used on show page to fetch a single active application by id
+ * Used on show page to fetch a single active application by either sanity id or planning id
  * @param id
  * @returns
  */
-export async function getActiveApplicationById(id: string) {
-  const query = `*[_type == "planning-application" && isActive == true && $_id in [_id, planningId] ${requiredFields}][0]`;
+export async function getActiveApplicationById(
+  id: string,
+  integrationMethod: IntegrationMethod,
+): Promise<PlanningApplication | null> {
+  try {
+    // If the id contains a dash, it's likely a Sanity document ID, otherwise it's a planning ID
+    // We only support fetching by planning ID if the integrationMethod is openAPI, otherwise we default to fetching by Sanity document ID
+    if (integrationMethod === "openAPI" && !id.includes("-")) {
+      return await getActiveApplicationByPlanningId(id);
+    } else {
+      return await getActiveApplicationBySanityId(id);
+    }
+  } catch (error) {
+    console.error("Error fetching application by ID:", error);
+    return null;
+  }
+}
+
+/**
+ * Fetch a single active application by id
+ * @param id
+ * @returns
+ */
+export async function getActiveApplicationBySanityId(id: string) {
+  const query = `*[_type == "planning-application" && isActive == true && $_id == _id ${requiredFields}][0]`;
+  const post = await client.fetch(query, { _id: id });
+  return post;
+}
+
+/**
+ * Fetch a single active application by PlanningId
+ * Only used if the OPEN_API_URL environment variable is set, otherwise we default to fetching by Sanity document ID
+ * @param id
+ * @returns
+ */
+export async function getActiveApplicationByPlanningId(id: string) {
+  const query = `*[_type == "planning-application" && isActive == true && $_id == planningId ${requiredFields}][0]`;
   const post = await client.fetch(query, { _id: id });
   return post;
 }

--- a/src/app/(main)/planning-applications/[id]/layout.tsx
+++ b/src/app/(main)/planning-applications/[id]/layout.tsx
@@ -1,4 +1,7 @@
-import { getActiveApplicationById } from "@/actions/sanityClient";
+import {
+  getActiveApplicationById,
+  getGlobalContent,
+} from "@/actions/sanityClient";
 import { ReactNode } from "react";
 import { HomeProps } from "./page";
 import { PlanningApplication } from "@/sanity/types";
@@ -11,8 +14,11 @@ import { PlanningApplication } from "@/sanity/types";
 export async function generateMetadata({ params }: HomeProps) {
   const { id } = params;
 
+  const globalContent = await getGlobalContent();
+
   const application = (await getActiveApplicationById(
     id,
+    globalContent?.integrations ?? "manual",
   )) as PlanningApplication | null;
   let firstHeading = "Planning application not found";
   let secondHeading = "Planning application not found";

--- a/src/app/(main)/planning-applications/[id]/page.tsx
+++ b/src/app/(main)/planning-applications/[id]/page.tsx
@@ -1,7 +1,10 @@
 import About from "@/components/about";
 import Impact from "@/components/impact";
 import Process from "@/components/process";
-import { getActiveApplicationById } from "@/actions/sanityClient";
+import {
+  getActiveApplicationById,
+  getGlobalContent,
+} from "@/actions/sanityClient";
 import { notFound } from "next/navigation";
 import { PlanningApplication } from "@/sanity/types";
 
@@ -14,10 +17,16 @@ export interface HomeProps {
   };
 }
 
-async function fetchData({ params }: HomeProps): Promise<PlanningApplication> {
+async function fetchData({
+  params,
+}: HomeProps): Promise<PlanningApplication | null> {
+  const globalContent = await getGlobalContent();
+
   const { id } = params;
-  const result = await getActiveApplicationById(id);
-  return result;
+  return await getActiveApplicationById(
+    id,
+    globalContent?.integrations ?? "manual",
+  );
 }
 
 const PlanningApplicationItem = async ({ params }: HomeProps) => {


### PR DESCRIPTION
We support for the endpoint `/planning-application/[id]` id can be either `_id` which is the unique sanity id or `planningId` which is specific to the open id use cases. 

This PR ensures that only sites using the openAPI integration method even try to fetch by planningId.

There is an issue where the `/planning-application/[sanityId]` pages will work immediately but `/planning-application/[planningId]` pages will not. 

This PR may fix this issue if it has something to do with nextJS's caching, I'm able to replicate the issue locally so its difficult to test. It this doesn't fix the issue we can still try [this](https://github.com/sanity-io/client?tab=readme-ov-file#nextjs-app-router).

[Notes on nextjs caching](https://nextjs.org/docs/14/app/building-your-application/caching)
